### PR TITLE
Adds the monarch ontology

### DIFF
--- a/download.yaml
+++ b/download.yaml
@@ -108,3 +108,8 @@
   url: https://raw.githubusercontent.com/obophenotype/zebrafish-phenotype-ontology/master/src/curation/id_map_zfin.tsv
   local_name: zfin/id_map_zfin.tsv
 
+
+# monarch
+-
+  url: https://ci.monarchinitiative.org/job/monarch-ontology-json-sri/479/artifact/build/monarch-ontology-final.json
+  local_name: monarch/monarch.json

--- a/merge.yaml
+++ b/merge.yaml
@@ -16,6 +16,11 @@ configuration:
 merged_graph:
   name: Monarch Graph
   source:
+    monarch_ontology:
+      input:
+        format: obojson
+        filename: # awkwardly merging out of the data directory here
+          - data/monarch/monarch.json
     alliance_gene:
       input:
         format: tsv

--- a/monarch_ingest/ingest_pipeline.py
+++ b/monarch_ingest/ingest_pipeline.py
@@ -69,11 +69,7 @@ def summarize(kgx: KgxGraph) -> KgxGraph:
 def merge(context, merge_files: List[KgxGraph]):
     # TODO:
     #  Consider writing a merge.yaml using a jinja template
-    #  This is successfuly filtering what goes into the merge, but it has to exist in the merge.yaml
-    #  which limits the benefit.
-
-    sources_to_include = [kgx_graph.name for kgx_graph in merge_files]
-    cli_utils.merge("merge.yaml", sources_to_include, processes=4)
+    cli_utils.merge("merge.yaml", processes=4)
 
 
 @dagster.graph


### PR DESCRIPTION
Fetched from the monarch jenkins server for now as part of the downloads yaml, and brought into the merge. I also removed the filtering based on upstream transforms, since monarch ontology wouldn't end up in the list.