### PR TITLE
MGI gene to pub ingest

### DIFF
--- a/docs/ingests/mgi.md
+++ b/docs/ingests/mgi.md
@@ -1,0 +1,27 @@
+Mouse Genome Informatics (MGI) is the international database resource for the laboratory mouse, providing integrated genetic, genomic, and biological data to facilitate the study of human health and disease.
+
+* [MGI bulk downloads](http://www.informatics.jax.org/downloads/reports/index.html)
+
+### Gene to Publication
+
+This ingest uses MGI's Reference download file, which contains genes and a tab-delimited list of PubMed IDs in which they are mentioned. 
+
+#### Biolink captured
+
+* biolink:Gene
+    * id
+    * source
+    * type
+
+* biolink:Publication
+    * id
+    * type
+    * source
+
+* biolink:NamedThingToInformationContentEntityAssociation
+    * id (random uuid)
+    * subject (gene.id)
+    * predicate (mentions)
+    * object (publication.id)
+    * relation (has phenotype)
+    * publication

--- a/download.yaml
+++ b/download.yaml
@@ -237,3 +237,8 @@
 -
   url: https://reactome.org/download/current/ChEBI2Reactome.txt
   local_name: data/reactome/ChEBI2Reactome.txt
+
+# mgi
+-
+  url: http://www.informatics.jax.org/downloads/reports/MRK_Reference.rpt
+  local_name: data/mgi/MRK_Reference.rpt

--- a/monarch_ingest/ingest_pipeline.py
+++ b/monarch_ingest/ingest_pipeline.py
@@ -84,27 +84,27 @@ def process(ingest: Ingest) -> KgxGraph:
 )
 def ingests(context):
     ingests = [
-        Ingest("alliance", "publication"),
         Ingest("alliance", "gene"),
         Ingest("alliance", "gene_to_phenotype"),
-        Ingest("rgd", "gene_to_publication"),
+        Ingest("alliance", "publication"),
+        Ingest("flybase", "gene_to_publication"),
+        Ingest("goa", "go_annotation"),
         Ingest("hgnc", "gene"),
         Ingest("hpoa", "disease_phenotype"),
-        Ingest("goa", "go_annotation"),
-        Ingest("flybase", "gene_to_publication"),
+        Ingest("mgi", "gene_to_publication"),
         Ingest("omim", "gene_to_disease"),
         Ingest("pombase", "gene"),
         Ingest("pombase", "gene_to_phenotype"),
+        Ingest("reactome", "chemical_to_pathway"),
+        Ingest("reactome", "gene_to_pathway"),
+        Ingest("rgd", "gene_to_publication"),
         Ingest("sgd", "gene_to_publication"),
         Ingest("string", "protein_links"),
         Ingest("xenbase", "gene"),
         Ingest("xenbase", "gene_to_phenotype"),
         Ingest("xenbase", "gene_to_publication"),
         Ingest("zfin", "gene_to_phenotype"),
-        Ingest("zfin", "gene_to_publication"),
-        Ingest("reactome", "gene_to_pathway"),
-        Ingest("reactome", "chemical_to_pathway"),
-        Ingest("mgi", "gene_to_publication")
+        Ingest("zfin", "gene_to_publication")
     ]
 
     for ingest in ingests:

--- a/monarch_ingest/ingest_pipeline.py
+++ b/monarch_ingest/ingest_pipeline.py
@@ -104,6 +104,7 @@ def ingests(context):
         Ingest("zfin", "gene_to_publication"),
         Ingest("reactome", "gene_to_pathway"),
         Ingest("reactome", "chemical_to_pathway"),
+        Ingest("mgi", "gene_to_publication")
     ]
 
     for ingest in ingests:

--- a/monarch_ingest/mgi/gene_to_publication.py
+++ b/monarch_ingest/mgi/gene_to_publication.py
@@ -1,0 +1,43 @@
+import uuid
+
+from biolink_model_pydantic.model import (
+    Gene,
+    NamedThingToInformationContentEntityAssociation,
+    Predicate,
+    Publication,
+)
+from koza.cli_runner import koza_app
+
+source_name = "mgi_gene_to_publication"
+
+row = koza_app.get_row(source_name)
+
+gene = Gene(
+    id=row["MGI Marker Accession ID"],
+    source="infores:mgi",
+    type=koza_app.translation_table.resolve_term("gene"),
+)
+
+pub_ids = row["PubMed IDs"].split("|")
+pubs = []
+for pub_id in pub_ids:
+    pmid = "PMID:" + pub_id
+    pubs.append(
+        Publication(
+            id=pmid,
+            type=koza_app.translation_table.resolve_term("publication"),
+            source="infores:mgi",
+        )
+    )
+
+    association = NamedThingToInformationContentEntityAssociation(
+        id="uuid:" + str(uuid.uuid1()),
+        subject=gene.id,
+        predicate=Predicate.mentions,
+        object=pmid,
+        relation=koza_app.translation_table.resolve_term("mentions"),
+        source="infores:mgi",
+    )
+
+for pub in pubs:
+    koza_app.write(gene, pub, association)  # , row_limit=5)

--- a/monarch_ingest/mgi/gene_to_publication.yaml
+++ b/monarch_ingest/mgi/gene_to_publication.yaml
@@ -1,0 +1,40 @@
+name: 'mgi_gene_to_publication'
+
+format: 'csv'
+
+delimiter: '\t'
+
+# list_delimiter: '|'
+
+header: 'none'
+
+files:
+  - './data/mgi/MRK_Reference.rpt'  # "http://www.informatics.jax.org/downloads/reports/MRK_Reference.rpt"
+
+global_table: './monarch_ingest/translation_table.yaml'
+
+columns:
+  - 'MGI Marker Accession ID'
+  - 'Marker Symbol'
+  - 'Marker Name'
+  - 'Marker Synonyms'
+  - 'PubMed IDs'
+
+node_properties:
+  - 'id'
+  - 'category'
+  - 'type'
+  - 'source'
+
+edge_properties:
+  - 'id'
+  - 'subject'
+  - 'predicate'
+  - 'object'
+  - 'category'
+  - 'relation'
+  - 'provided_by'
+  - 'source'
+
+transform_mode: 'flat'
+

--- a/monarch_ingest/mgi/metadata.yaml
+++ b/monarch_ingest/mgi/metadata.yaml
@@ -1,0 +1,4 @@
+ingest_title: 'MGI'
+ingest_url: 'http://www.informatics.jax.org'
+description: 'MGI: Mouse Genome Informatics'
+rights: 'http://www.informatics.jax.org/mgihome/other/copyright.shtml'

--- a/tests/unit/mgi/test_mgi_gene_to_publication.py
+++ b/tests/unit/mgi/test_mgi_gene_to_publication.py
@@ -1,0 +1,53 @@
+import pytest
+from biolink_model_pydantic.model import (
+    Gene,
+    NamedThingToInformationContentEntityAssociation,
+    Publication,
+)
+
+pubmed_ids = "11217851|12466851|18163442|21267068|19213785|27357688|27914912|21873635|31504408"
+markers = "Cbe1|Smrp1"
+
+@pytest.fixture
+def source_name():
+    return "mgi_gene_to_publication"
+
+
+@pytest.fixture
+def script():
+    return "./monarch_ingest/mgi/gene_to_publication.py"
+
+@pytest.fixture
+def basic_row():
+    return {
+        "MGI Marker Accession ID":"MGI:1920971",
+        "Marker Symbol":"1110017D15Rik",
+        "Marker Name":"RIKEN cDNA 1110017D15 gene",
+        "Marker Synonyms":markers,
+        "PubMed IDs":pubmed_ids
+    }
+
+@pytest.fixture
+def basic_entities(mock_koza, source_name, basic_row, script, global_table):
+    return mock_koza(
+        source_name,
+        iter([basic_row]),
+        script,
+        global_table=global_table,
+    )
+
+def test_gene(basic_entities):
+    print("basic_entities: ",basic_entities)
+    gene = [entity for entity in basic_entities if isinstance(entity, Gene)][0]
+    assert gene.id == "MGI:1920971"
+
+
+def test_pub(basic_entities):
+    pub = [entity for entity in basic_entities if isinstance(entity, Publication)][0]
+    assert str(pub.id)[5:] in pubmed_ids
+
+
+def test_association(basic_entities):
+    association = [entity for entity in basic_entities if isinstance(entity, NamedThingToInformationContentEntityAssociation)][0]
+    assert association.subject == "MGI:1920971"
+    assert association.object == "PMID:31504408"


### PR DESCRIPTION
Create ingest of MGI Gene to Publication data. 

Note: this is still on version 0.1.2 of Biolink Model Pydantic. 

When that's updated to latest, we'll want to update all tests/scripts to:
- Change `NamedThingToInformationContentEntityAssociation` to `InformationContentEntityToNamedThingAssociation`
- Switch the order of objects and subjects in "gene_to_publication" ingest files
    - Does this make them "publication_to_gene" ingests now? 
- Change `predicate.mentions` to `predicate.mentioned_by`