### PR TITLE
added filter to only include protein coding genes in pombase gene ingest

### DIFF
--- a/monarch_ingest/ingests/pombase/gene.yaml
+++ b/monarch_ingest/ingests/pombase/gene.yaml
@@ -12,6 +12,12 @@ global_table: './monarch_ingest/translation_table.yaml'
 
 header: none
 
+filters:
+  - inclusion: 'include'
+    column: "product type"
+    filter_code: 'eq'
+    value: 'protein coding gene'
+
 columns:
   - "systematic ID"
   - "curie"


### PR DESCRIPTION
This addresses https://github.com/monarch-initiative/helpdesk/issues/28 