### PR TITLE
Add category to edge_property list for bGee

### DIFF
--- a/monarch_ingest/ingests/bgee/gene_to_expression.yaml
+++ b/monarch_ingest/ingests/bgee/gene_to_expression.yaml
@@ -69,6 +69,7 @@ filters:
 # For node-only ingests
 edge_properties:
   - 'id'
+  - 'category'
   - 'subject'
   - 'predicate'
   - 'object'


### PR DESCRIPTION
I noticed that in the latest build that the category column was blank for all of bGee. It really would be nice if this whole edge_property thing was less error touchy - definitely something to improve about Koza in the future. 
 