### PR TITLE
Solr field types, dynamic fields and copy fields configuration

### DIFF
--- a/scripts/add_entity_copyfields.sh
+++ b/scripts/add_entity_copyfields.sh
@@ -16,7 +16,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
         "name": "*_t",
         "type": "text",
         "indexed": true,
-        "stored": true,
+        "stored": false,
         "multiValued": true
     }
 }' http://localhost:8983/solr/entity/schema
@@ -28,7 +28,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
         "name": "*_ac",
         "type": "autocomplete",
         "indexed": true,
-        "stored": true,
+        "stored": false,
         "multiValued": true
     }
 }' http://localhost:8983/solr/entity/schema

--- a/scripts/add_entity_copyfields.sh
+++ b/scripts/add_entity_copyfields.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+# Add two dynamicfields declarations to the schema
+
+# One for text fields, have to replace because _t comes built in
+
+# delete the _t dynamic field
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+    "delete-dynamic-field": {
+        "name": "*_t"
+    }
+}' http://localhost:8983/solr/entity/schema
+
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+    "add-dynamic-field": {
+        "name": "*_t",
+        "type": "text",
+        "indexed": true,
+        "stored": true,
+        "multiValued": true
+    }
+}' http://localhost:8983/solr/entity/schema
+
+# One for autocomplete fields
+
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+    "add-dynamic-field": {
+        "name": "*_ac",
+        "type": "autocomplete",
+        "indexed": true,
+        "stored": true,
+        "multiValued": true
+    }
+}' http://localhost:8983/solr/entity/schema
+
+
+# now add copyfields declarations for name, symbol and synonym
+
+# name
+
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+    "add-copy-field": {
+        "source": "name",
+        "dest": "name_t"
+    }
+}' http://localhost:8983/solr/entity/schema
+
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+    "add-copy-field": {
+        "source": "name",
+        "dest": "name_ac"
+    }
+}' http://localhost:8983/solr/entity/schema
+
+# symbol
+
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+    "add-copy-field": {
+        "source": "symbol",
+        "dest": "symbol_t"
+    }
+}' http://localhost:8983/solr/entity/schema
+
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+    "add-copy-field": {
+        "source": "symbol",
+        "dest": "symbol_ac"
+    }
+}' http://localhost:8983/solr/entity/schema
+
+# synonym
+
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+    "add-copy-field": {
+        "source": "synonym",
+        "dest": "synonym_t"
+    }
+}' http://localhost:8983/solr/entity/schema
+
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+    "add-copy-field": {
+        "source": "synonym",
+        "dest": "synonym_ac"
+    }
+}' http://localhost:8983/solr/entity/schema
+

--- a/scripts/add_entity_fieldtypes.sh
+++ b/scripts/add_entity_fieldtypes.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+  "add-field-type": {
+    "name": "text",
+    "class": "solr.TextField",
+    "positionIncrementGap": "100",
+    "indexAnalyzer": {
+      "tokenizer": {
+        "class": "solr.StandardTokenizerFactory"
+      },
+      "filters": [
+        {
+          "class": "solr.WordDelimiterGraphFilterFactory",
+          "generateWordParts":"1",
+          "generateNumberParts":"1",
+          "catenateWords":"1",
+          "catenateNumbers":"1",
+          "catenateAll":"1",
+          "splitOnCaseChange":"0",
+          "preserveOriginal":"1",
+          "splitOnNumerics":"0"
+        },
+        { "class": "solr.FlattenGraphFilterFactory" },
+        { "class": "solr.ASCIIFoldingFilterFactory" },
+        { "class": "solr.LowerCaseFilterFactory" },
+        { "class": "solr.KeywordMarkerFilterFactory", "protected":"protwords.txt" },
+        { "class": "solr.EnglishMinimalStemFilterFactory" },
+        { "class": "solr.RemoveDuplicatesTokenFilterFactory" }
+      ]
+    },
+    "queryAnalyzer" : {
+      "tokenizer": {
+        "class": "solr.StandardTokenizerFactory"
+      },
+      "filters": [
+        { "class": "solr.StopFilterFactory", "ignoreCase":"true", "words":"stopwords.txt" },
+        { "class": "solr.WordDelimiterGraphFilterFactory",
+          "generateWordParts":"1",
+          "generateNumberParts":"1",
+          "catenateWords":"0",
+          "catenateNumbers":"0",
+          "catenateAll":"1",
+          "splitOnCaseChange":"0",
+          "preserveOriginal":"1",
+          "splitOnNumerics":"0"
+        }
+        { "class": "solr.ASCIIFoldingFilterFactory" },
+        { "class": "solr.LowerCaseFilterFactory" },
+        { "class": "solr.KeywordMarkerFilterFactory", "protected":"protwords.txt" },
+        { "class": "solr.EnglishMinimalStemFilterFactory" },
+        { "class": "solr.RemoveDuplicatesTokenFilterFactory" }
+      ]
+    }
+  }
+}' http://localhost:8983/solr/entity/schema
+
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+    "add-field-type": {
+      "name": "autocomplete",
+      "class": "solr.TextField",
+      "positionIncrementGap": "100",
+      "indexAnalyzer": {
+        "tokenizer": { "class": "solr.StandardTokenizerFactory" },
+        "filters": [
+          { "class": "solr.ASCIIFoldingFilterFactory" },
+          { "class": "solr.LowerCaseFilterFactory" },
+          {
+            "class": "solr.EdgeNGramFilterFactory",
+            "minGramSize": "1",
+            "maxGramSize": "25"
+          }
+        ]
+      },
+      "queryAnalyzer": {
+        "tokenizer": { "class": "solr.StandardTokenizerFactory" },
+        "filters": [
+          { "class": "solr.ASCIIFoldingFilterFactory" },
+          { "class": "solr.LowerCaseFilterFactory" }
+        ]
+      }
+    }
+}' http://localhost:8983/solr/entity/schema

--- a/scripts/load_solr.sh
+++ b/scripts/load_solr.sh
@@ -21,12 +21,23 @@ sleep 30
 echo "Adding cores"
 poetry run lsolr add-cores entity association
 sleep 10
+
+# todo: ideally, this will live in linkml-solr
+echo "Adding additional fieldtypes"
+scripts/add_entity_fieldtypes.sh
+sleep 5
+
 echo "Adding entity schema"
 poetry run lsolr create-schema -C entity -s model.yaml
 sleep 5
 
 echo "Adding association schema"
 poetry run lsolr create-schema -C association -s model.yaml
+sleep 5
+
+# todo: this also should live in linkml-solr, and copy-fields should be based on the schema
+echo "Add dynamic fields and copy fields declarations"
+scripts/add_entity_copyfields.sh
 sleep 5
 
 echo "Loading entities"
@@ -39,6 +50,9 @@ curl "http://localhost:8983/solr/association/select?q=*:*"
 mkdir solr-data || true
 
 docker cp my_solr:/var/solr/data solr-data/
+
+# make sure it's readable by all in the tar file
+chmod -R a+rX solr-data
 
 # For now, just leaving solr running. It will go away on it's own in the jenkins builder
 # and otherwise that makes this script a nice way to just run solr locally


### PR DESCRIPTION
Closes #296

This is more of a short term solution than long term, but I didn't feel confident about solving this generically in linkml-solr without first making a more concrete solution. 

The ultimate goal here is to give us two new tokenized fields for search & autocomplete matching against the solr index. 

I brought over the field type configuration for both fields from ZFIN. I think the autocomplete field config should be pretty straightforward. The text configuration may need some tweaking, depending on tokenization edge cases. (Do we want to tokenize on word/number boundaries? which punctuation? etc) 

Ultimately, it's probably low stakes until/unless we get genotype names, or find that people have very specific expectations when searching for GO or CHEBI terms with lots of punctuation.
