### PR TITLE
Add mesh to chebi biomappings

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -237,6 +237,7 @@ def merge_files(
     mappings = []
     mappings.append("data/monarch/mondo.sssom.tsv")
     mappings.append("data/monarch/gene_mappings.tsv")
+    mappings.append("data/monarch/chebi-mesh.biomappings.sssom.tsv")
 
     logger.info("Merging knowledge graph...")
 


### PR DESCRIPTION
Starts using the mesh to chebi mappings for ctd ingest. We'll need to actually add it to download.yaml once it's officially in the mapping commons repo. Only adds 334 CTD edges, but that's better than zero.
