### PR TITLE
Produce jsonl version of graph with category closure populated and load into neo4j artifact

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,9 +53,10 @@ pipeline {
                 sh 'poetry run kgx graph-summary -i tsv -c "tar.gz" --node-facet-properties provided_by --edge-facet-properties provided_by output/monarch-kg.tar.gz -o output/merged_graph_stats.yaml'
             }
         }
+        stage('jsonl-conversion')
         stage('kgx-transforms'){
             steps {
-                sh './scripts/kgx_transforms.sh'
+                sh 'poetry run ingest jsonl'
             }
         }
         stage('denormalize') {

--- a/neo4j-transform.yaml
+++ b/neo4j-transform.yaml
@@ -6,10 +6,10 @@ transform:
     monarch-kg:
       input:
         name: "Monarch KG"
-        format: tsv
-        compression: tar.gz
+        format: jsonl
         filename:
-          - output/monarch-kg.tar.gz
+          - output/monarch-kg_edges.jsonl
+          - output/monarch-kg_nodes.jsonl
       output:
         format: neo4j
         uri: neo4j://localhost:7687

--- a/scripts/kgx_transforms.sh
+++ b/scripts/kgx_transforms.sh
@@ -1,22 +1,20 @@
 #!/bin/bash
 
-echo "kgx transform to jsonl"
-# poetry run kgx transform -i tsv -c tar.gz -f jsonl -d tar.gz -o output/monarch-kg.jsonl.tar.gz output/monarch-kg.tar.gz
-poetry run kgx transform -i tsv -c tar.gz -f jsonl -o output/monarch-kg output/monarch-kg.tar.gz
-# create tar archive named output/monarch-kg.json.tar.gz that includes output/monarch-kg_nodes.jsonl and output/monarch-kg_edges.jsonl
-tar -C output -czvf monarch-kg.jsonl.tar.gz monarch-kg_nodes.jsonl monarch-kg_edges.jsonl
 
 
-rm output/monarch-kg_edges.jsonl
-rm output/monarch-kg_nodes.jsonl
+#rm output/monarch-kg_edges.jsonl
+#rm output/monarch-kg_nodes.jsonl
 echo "kgx transform to rdf"
 poetry run kgx transform -i tsv -c tar.gz -f nt -d gz -o output/monarch-kg.nt.gz output/monarch-kg.tar.gz
 
 
 echo "Building Neo4j Artifact"
 docker rm -f neo || True
+tar -C output -xzf output/monarch-kg.jsonl.tar.gz
 mkdir neo4j-v4-data
 docker run -d --name neo -p7474:7474 -p7687:7687 -v neo4j-v4-data:/data --env NEO4J_AUTH=neo4j/admin neo4j:4.4
 poetry run kgx transform --stream --transform-config neo4j-transform.yaml > kgx-transform.log
 docker stop neo
 docker run -v $(pwd)/output:/backup -v neo4j-v4-data:/data --entrypoint neo4j-admin neo4j:4.4 dump --to /backup/monarch-kg.neo4j.dump
+rm output/monarch-kg_nodes.jsonl
+rm output/monarch-kg_edges.jsonl

--- a/src/monarch_ingest/main.py
+++ b/src/monarch_ingest/main.py
@@ -4,6 +4,7 @@ from kghub_downloader.download_utils import download_from_yaml
 from monarch_ingest.cli_utils import (
     apply_closure, 
     do_release,
+    load_jsonl,
     load_sqlite, 
     load_solr, 
     merge_files, 
@@ -103,6 +104,9 @@ def merge(
 def closure():
     apply_closure()
 
+@typer_app.command()
+def jsonl():
+    load_jsonl()
 
 @typer_app.command()
 def sqlite():


### PR DESCRIPTION
Doing the kgx tsv to jsonlines conversion in pandas rather than in kgx so that the category closure can be populated in the process. The jsonl files are then used to load into neo4j, which now has complete category labels

fixes #462 
fixes #463 