### PR TITLE
Fix missing genes happening due to missing taxon info

### DIFF
--- a/src/monarch_ingest/ingests.yaml
+++ b/src/monarch_ingest/ingests.yaml
@@ -20,8 +20,8 @@ goa_go_annotation:
   config: 'ingests/goa/go_annotation.yaml'
 hgnc_gene:
   config: 'ingests/hgnc/gene.yaml'
-hpoa_disease_phenotype:
-  config: 'ingests/hpoa/disease_phenotype.yaml'
+hpoa_disease_to_phenotype:
+  config: 'ingests/hpoa/disease_to_phenotype.yaml'
 hpoa_gene_to_disease:
   config: 'ingests/hpoa/gene_to_disease.yaml'
 hpoa_disease_mode_of_inheritance:

--- a/src/monarch_ingest/ingests/dictybase/gene.py
+++ b/src/monarch_ingest/ingests/dictybase/gene.py
@@ -5,13 +5,15 @@ from biolink.pydanticmodel import Gene
 koza_app = get_koza_app("dictybase_gene")
 taxon_labels = koza_app.get_map("taxon-labels")
 
+in_taxon = "NCBITaxon:44689"
+in_taxon_label = taxon_labels[in_taxon]['label'] if in_taxon in taxon_labels else "Dictyostelium discoideum"
+
 while (row := koza_app.get_row()) is not None:
     
     synonyms = []
     if row['Synonyms'] is not None:
         synonyms = row['Synonyms'].split(", ")
 
-    in_taxon = "NCBITaxon:44689"
 
     gene = Gene(
         id='dictyBase:' + row['GENE ID'],
@@ -20,7 +22,7 @@ while (row := koza_app.get_row()) is not None:
         full_name=row['Gene Name'],
         synonym=synonyms,
         in_taxon=[in_taxon],
-        in_taxon_label=taxon_labels[in_taxon]['label'],
+        in_taxon_label=in_taxon_label,
         provided_by=["infores:dictybase"]
     )
 

--- a/src/monarch_ingest/ingests/ncbi/gene.py
+++ b/src/monarch_ingest/ingests/ncbi/gene.py
@@ -5,10 +5,23 @@ from biolink.pydanticmodel import Gene
 koza_app = get_koza_app("ncbi_gene")
 taxon_labels = koza_app.get_map("taxon-labels")
 
+# If a taxon label we need isn't in phenio's NCBITaxon subset, we can add it here
+extra_taxon_labels = {
+    'NCBITaxon:227321': 'Dictyostelium discoideum'
+}
+
 while (row := koza_app.get_row()) is not None:
 
     in_taxon = 'NCBITaxon:' + row["tax_id"]
-    in_taxon_label = taxon_labels[in_taxon]["label"]
+
+
+    if in_taxon in taxon_labels:
+        in_taxon_label = taxon_labels[in_taxon]['label']
+    elif in_taxon in extra_taxon_labels:
+        in_taxon_label = extra_taxon_labels[in_taxon]
+    else:
+        raise ValueError(f"Taxon {in_taxon} not found in taxon-labels")
+
     gene = Gene(
         id='NCBIGene:' + row["GeneID"],
         symbol=row["Symbol"],


### PR DESCRIPTION
Fixes #490

The dictybase ingest & aspergillus genes from the NCBI ingest were both getting silently skipped when the taxon map lookup failed while getting passed into the pydantic constructor. It didn't halt the ingest in either case, but the loop terminated before a write. I didn't fix the weird silent-ness of the failure at the koza/pydantic level, but I did hard code the taxon names so that the genes come back

