### PR TITLE
add sources landing page

### DIFF
--- a/docs/Sources/index.md
+++ b/docs/Sources/index.md
@@ -1,0 +1,6 @@
+# Data Sources
+
+This section contains detailed information on all datasets and ontologies  
+ingested to create the Monarch knowledge graph.  
+
+To learn more about a specific dataset/ontology, click on the source name in the list to the left.  

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -17,6 +17,7 @@ nav:
   - KG Build Process: 'KG-Build-Process/kg-build-process.md'
   - Principles: 'Principles/modeling-principles.md'
   - Sources:
+    - Overview: 'Sources/index.md'
     - Alliance: 'Sources/alliance.md'
     - BGee: 'Sources/bgee.md'
     - CTD: 'Sources/ctd.md'


### PR DESCRIPTION
Adds a landing page for the Sources section, mainly so monarch app can link to it without going directly to Alliance