### PR TITLE
Added extra knowledge source fields for translator

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -347,6 +347,10 @@ def load_jsonl():
             edges_df = pandas.read_csv(edge_file, sep="\t", dtype="string", lineterminator="\n", quoting=csv.QUOTE_NONE,
                                    comment='#')
             edges_df["category"] = edges_df["category"].map(class_ancestor_dict)
+            # Prefixing only these two fields is an odd thing that Translator needs, so
+            # they're being duplicated with the prefixes here
+            edges_df["biolink:primary_knowledge_source"] = edges_df["primary_knowledge_source"]
+            edges_df["biolink:aggregator_knowledge_source"] = edges_df["aggregator_knowledge_source"]
             edges_df.to_json("output/monarch-kg_edges.jsonl", orient="records", lines=True)
             del edges_df
             gc.collect()


### PR DESCRIPTION
Just needed to have a version of primary & aggregate knowledge source fields that have a biolink prefix in the field name in the jsonl/neo4j versions of the graph
