### PR TITLE
Update pombase curie prefix in ingest & tests

### DIFF
--- a/src/monarch_ingest/ingests/panther/orthology_utils.py
+++ b/src/monarch_ingest/ingests/panther/orthology_utils.py
@@ -50,7 +50,7 @@ _db_to_curie = {
     "FlyBase": "FB",
     "Ensembl": "ENSEMBL",
     "EnsemblGenome": "ENSEMBL",  # TODO: review and fix this later?
-    "PomBase": "POMBASE",
+    "PomBase": "PomBase",
     "WormBase": "WB",  # Wormbase supports 'WormBase:' but alliancegenome.org and identifiers.org supports 'WB:'
     "GeneID": "NCBIGene",          # seems to be Entrez Gene ID => map onto the NCBIGene: namespace
     "Gene": None,                  # seems to be the gene symbol - we ignore it for now?

--- a/tests/unit/panther/test_genome_orthologs.py
+++ b/tests/unit/panther/test_genome_orthologs.py
@@ -49,7 +49,7 @@ result_expected = {
         "RO:HOM0000017",
         "PANTHER.FAMILY:PTHR12434",
     ],
-    "POMBASE:SPAC20G8.06": [
+    "PomBase:SPAC20G8.06": [
         "ZFIN:ZDB-GENE-040915-1",
         "NCBITaxon:7955",
         "NCBITaxon:4896",


### PR DESCRIPTION
This should bring back panther dangling edges connecting to PomBase genes. I think initially the biolink model had the prefix defined as POMBASE, and we shifted our gene & gene to phenotype ingests over, but not this one. 

Fixes #520 