### PR TITLE
Partial resolution of Monarch App issue#393

### DIFF
--- a/src/monarch_ingest/ingests/string/protein_links.py
+++ b/src/monarch_ingest/ingests/string/protein_links.py
@@ -1,11 +1,14 @@
 import uuid
-
+from typing import Optional, List
 
 from koza.cli_runner import get_koza_app
 
 from biolink.pydanticmodel import PairwiseGeneToGeneInteraction
 
 from loguru import logger
+
+from string_utils import map_evidence_codes
+
 koza_app = get_koza_app("string_protein_links")
 
 while (row := koza_app.get_row()) is not None:
@@ -28,6 +31,8 @@ while (row := koza_app.get_row()) is not None:
 
         entities = []
 
+        has_evidence: List[str] = map_evidence_codes(row)
+
         for gid_a in gene_ids_a.split("|"):
 
             for gid_b in gene_ids_b.split("|"):
@@ -41,6 +46,10 @@ while (row := koza_app.get_row()) is not None:
                     subject=gene_id_a,
                     object=gene_id_b,
                     predicate="biolink:interacts_with",
+
+                    # sanity check: set to 'None' if empty list
+                    has_evidence=has_evidence if has_evidence else None,
+
                     aggregator_knowledge_source=["infores:monarchinitiative"],
                     primary_knowledge_source="infores:string"
                 )

--- a/src/monarch_ingest/ingests/string/protein_links.yaml
+++ b/src/monarch_ingest/ingests/string/protein_links.yaml
@@ -58,5 +58,6 @@ edge_properties:
   - 'object'
   - 'aggregator_knowledge_source'
   - 'primary_knowledge_source'
+  - 'has_evidence'
 
 transform_mode: 'flat'

--- a/src/monarch_ingest/ingests/string/string_utils.py
+++ b/src/monarch_ingest/ingests/string/string_utils.py
@@ -1,0 +1,60 @@
+##########################################
+# STRING ingest utility functions
+##########################################
+from typing import Dict, List
+
+#
+# Mapping of STRING evidence type score fields to evidence & conclusion codes (with definitions)
+#
+#
+# "neighborhood" score, (computed from the inter-gene nucleotide count) - ECO:0000044: SEQUENCE SIMILARITY EVIDENCE.
+# A sequence similarity analysis may involve a gene or a gene product, and it could be based on similarity
+# to a single other gene or to a group of other genes.
+#
+# "fusion" score (derived from fused proteins in other species)
+# - ECO:0000124: FUSION PROTEIN LOCALIZATION EVIDENCE.
+# A type of protein localization evidence resulting from the fusion of a protein of interest
+# to a labeling protein which has enzymatic activity or fluorescence properties.
+#
+# "cooccurrence" score of the phyletic profile (derived from similar absence/presence patterns of genes)
+# ECO:0000080:PHYLOGENETIC EVIDENCE.
+# A type of similarity that indicates common ancestry.
+#
+# "coexpression" score (derived from similar pattern of mRNA expression measured by DNA arrays and similar technologies)
+# ECO:0000075: GENE EXPRESSION SIMILARITY EVIDENCE.
+# A type of phenotypic similarity evidence that is based on the
+# categorization of genes by the similarity of expression profiles.
+#
+# "experimental" score (derived from experimental data, such as, affinity chromatography)
+# ECO:0000006: EXPERIMENTAL EVIDENCE.
+# experimental evidence: A type of evidence that is the output of a scientific procedure
+# performed to make a discovery, test a hypothesis, or demonstrate a known fact.
+#
+# "database" score (derived from curated data of various databases)
+# ECO:0007636: CURATOR INFERENCE FROM DATABASE.
+# A type of curator inference from authoritative resource based
+# on information located in a queryable database and is optimized for computers.
+#
+# "textmining" score (derived from the co-occurrence of gene/protein names in abstracts)
+# ECO:0007833: CURATOR INFERENCE FROM AUTHORITATIVE SOURCE USED IN AUTOMATIC ASSERTION.
+# A type of curator inference from authoritative source that is used in an automatic assertion.
+
+EVIDENCE_CODE_MAPPINGS = {
+    "neighborhood": "ECO:0000044",
+    "fusion": "ECO:0000124",
+    "cooccurence": "ECO:0000080",
+    "coexpression": "ECO:0000075",
+    "experimental": "ECO:0000006",
+    "database": "ECO:0007636",
+    "textmining": "ECO:0007833"
+}
+
+
+def map_evidence_codes(row: Dict) -> List[str]:
+    eco_mappings: List[str] = list()
+    for evidence_type in EVIDENCE_CODE_MAPPINGS.keys():
+        if int(row[evidence_type]) > 0:
+            eco_mappings.append(EVIDENCE_CODE_MAPPINGS[evidence_type])
+
+    return eco_mappings
+

--- a/tests/unit/string/test_string_protein_links.py
+++ b/tests/unit/string/test_string_protein_links.py
@@ -106,6 +106,8 @@ def basic_pl(mock_koza, source_name, basic_row, script, global_table, map_cache)
 #     assert "NCBITaxon:10090" in gene_b.in_taxon
 
 #     assert gene_b.source == "infores:entrez"
+INCLUDED_ECO_CODES = ['ECO:0000075', 'ECO:0000006', 'ECO:0007833']
+EXCLUDED_ECO_CODES = ['ECO:0000044', 'ECO:0000124', 'ECO:0000080', 'ECO:0007636']
 
 
 def test_association(basic_pl):
@@ -115,6 +117,9 @@ def test_association(basic_pl):
     assert association.object == "NCBIGene:56480"
     assert association.predicate == "biolink:interacts_with"
     assert association.primary_knowledge_source == "infores:string"
+    assert association.has_evidence
+    assert all([eco_code in INCLUDED_ECO_CODES for eco_code in association.has_evidence])
+    assert all([eco_code not in EXCLUDED_ECO_CODES for eco_code in association.has_evidence])
     assert "infores:monarchinitiative" in association.aggregator_knowledge_source
 
 


### PR DESCRIPTION
Maps and returns Evidence and Conclusion codes for evidence type columns with scores > 0. This doesn't completely get to the reviewer's point about ingesting and citing original STRING sources, but it generally highlights the nature of the evidence supporting the STRING statement.