### PR TITLE
Add \r scrubbing for transform output and rdf

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,16 @@ pipeline {
         stage('transform') {
             steps {
                 sh 'poetry run ingest transform --all --log --rdf'
+                sh '''
+                   sed -i.bak 's@\r@@g' output/transform_output/*.tsv
+                   rm output/transform_output/*.bak
+                '''
+                sh '''
+                   gunzip output/rdf/*.gz
+                   sed -i.bak 's@\\r@@g' output/rdf/*.nt
+                   rm output/rdf/*.bak
+                   gzip output/rdf/*.nt
+                '''
             }
         }
         stage('merge') {


### PR DESCRIPTION
Use sed to clean out ^M (\r) characters from transform_output & rdf. Koza passes them through just fine, and cat-merge is ok with them, but petl within closurizer treats them as newlines. boo.
