### PR TITLE
Add TSV export, borrowing from release-utils

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,6 +89,11 @@ pipeline {
                 sh 'poetry run ingest sqlite'
             }
         }
+        stage('make exports') {
+            steps {
+                sh 'poetry run ingest export'
+            }
+        }
         stage('upload files') {
             steps {
                 sh 'poetry run ingest release --kghub'

--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -23,6 +23,7 @@ from linkml_runtime.utils.formatutils import camelcase
 
 from monarch_ingest.utils.ingest_utils import ingest_output_exists, file_exists, get_ingests
 from monarch_ingest.utils.log_utils import get_logger
+from monarch_ingest.utils.export_utils import export
 
 # from koza.utils.log_utils import get_logger
 
@@ -401,6 +402,8 @@ def load_jsonl():
     os.remove("output/monarch-kg_nodes.jsonl")
     os.remove("output/monarch-kg_edges.jsonl")
 
+def export_tsv():
+    export()
 
 def do_release(dir: str = OUTPUT_DIR, kghub: bool = False):
     import datetime

--- a/src/monarch_ingest/data-dump-config.yaml
+++ b/src/monarch_ingest/data-dump-config.yaml
@@ -1,0 +1,52 @@
+---
+disease_associations:
+  disease_phenotype.all.tsv.gz:
+  - 'category:"biolink:DiseaseToPhenotypicFeatureAssociation"'
+gene_associations:
+  gene_phenotype.all.tsv.gz:
+  - 'category:"biolink:GeneToPhenotypicFeatureAssociation"'
+  gene_phenotype.4896.tsv.gz:
+  - 'category:"biolink:GeneToPhenotypicFeatureAssociation"'
+  - 'subject_taxon:"NCBITaxon:4896"'
+  gene_phenotype.6239.tsv.gz:
+  - 'category:"biolink:GeneToPhenotypicFeatureAssociation"'
+  - 'subject_taxon:"NCBITaxon:6239"'
+  gene_phenotype.7955.tsv.gz:
+  - 'category:"biolink:GeneToPhenotypicFeatureAssociation"'
+  - 'subject_taxon:"NCBITaxon:7955"'
+  gene_phenotype.8355.tsv.gz:
+  - 'category:"biolink:GeneToPhenotypicFeatureAssociation"'
+  - 'subject_taxon:"NCBITaxon:8355"'
+  gene_phenotype.8364.tsv.gz:
+  - 'category:"biolink:GeneToPhenotypicFeatureAssociation"'
+  - 'subject_taxon:"NCBITaxon:8364"'
+  gene_phenotype.9606.tsv.gz:
+  - 'category:"biolink:GeneToPhenotypicFeatureAssociation"'
+  - 'subject_taxon:"NCBITaxon:9606"'
+  gene_phenotype.10090.tsv.gz:
+  - 'category:"biolink:GeneToPhenotypicFeatureAssociation"'
+  - 'subject_taxon:"NCBITaxon:10090"'
+  gene_phenotype.10116.tsv.gz:
+  - 'category:"biolink:GeneToPhenotypicFeatureAssociation"'
+  - 'subject_taxon:"NCBITaxon:10116"'
+# Leaving as a placeholder because we don't have fly g2p right now
+#  gene_phenotype.7227.tsv.gz:
+#  - 'category:"biolink:GeneToPhenotypicFeatureAssociation"'
+#  - 'subject_taxon:"NCBITaxon:7227"'
+# Leaving as a placeholder for a long tail of species that may come from OMIA
+#  gene_phenotype.other.tsv.gz:
+#  - 'category:"biolink:GeneToPhenotypicFeatureAssociation"'
+#  - '-subject_taxon:"NCBITaxon:4896"'
+#  - '-subject_taxon:"NCBITaxon:6239"'
+#  - '-subject_taxon:"NCBITaxon:7227"'
+#  - '-subject_taxon:"NCBITaxon:7955"'
+#  - '-subject_taxon:"NCBITaxon:8355"'
+#  - '-subject_taxon:"NCBITaxon:8364"'
+#  - '-subject_taxon:"NCBITaxon:9606"'
+#  - '-subject_taxon:"NCBITaxon:10090"'
+#  - '-subject_taxon:"NCBITaxon:10116"'
+  gene_disease.9606.tsv.gz:
+  - 'category:"biolink:CausalGeneToDiseaseAssociation"'
+  - 'subject_taxon:"NCBITaxon:9606"'
+  gene_disease.noncausal.tsv.gz:
+  - 'category:"biolink:CorrelatedGeneToDiseaseAssociation"'

--- a/src/monarch_ingest/main.py
+++ b/src/monarch_ingest/main.py
@@ -4,6 +4,7 @@ from kghub_downloader.download_utils import download_from_yaml
 from monarch_ingest.cli_utils import (
     apply_closure, 
     do_release,
+    export_tsv,
     load_jsonl,
     load_sqlite, 
     load_solr, 
@@ -117,6 +118,9 @@ def sqlite():
 def solr():
     load_solr()
 
+@typer_app.command()
+def export():
+    export_tsv()
 
 @typer_app.command()
 def release(

--- a/src/monarch_ingest/utils/export_utils.py
+++ b/src/monarch_ingest/utils/export_utils.py
@@ -1,0 +1,285 @@
+
+""" Monarch Data Dump
+
+This script is used to dump tsv files from the
+Monarch association index
+
+The input is a yaml configuration with the format:
+
+directory_name:
+  file_name.tsv:
+  - solr_filter_1
+  - solr_filter_2
+"""
+import json
+from json import decoder
+from enum import Enum
+from pathlib import Path
+import logging
+import yaml
+import gzip
+import time
+import re
+
+import requests
+from requests.adapters import HTTPAdapter
+from requests.exceptions import ChunkedEncodingError
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class OutputType(str, Enum):
+    tsv = 'tsv'
+    jsonl = 'jsonl'
+
+
+OUTPUT_TYPES = set(OutputType._member_names_)
+
+
+def export(config_file: str = "./src/monarch_ingest/data-dump-config.yaml",
+           output_dir: str = "./output/tsv/",
+           output_format: OutputType = OutputType.tsv,
+           solr_url: str = "http://localhost:8983/solr/association/select"):
+
+    if output_format not in OUTPUT_TYPES:
+        raise ValueError(f"output format not supported, supported formats are {OUTPUT_TYPES}")
+
+    dir_path = Path(output_dir)
+
+    # Fetch all associations
+    association_dir = 'all_associations'
+    dump_dir = dir_path / association_dir
+    dump_dir.mkdir(parents=True, exist_ok=True)
+
+    # wt=json&facet=true&json.nl=arrarr&rows=0&q=*:*&facet.field=association_type
+    assoc_params = {
+        'q': '*:*',
+        'wt': 'json',
+        'json.nl': 'arrarr',
+        'rows': 0,
+        'facet': 'true',
+        'facet.field': 'category'
+    }
+
+    solr_request = requests.get(solr_url, params=assoc_params)
+    response = solr_request.json()
+    solr_request.close()
+
+    for facet in reversed(response['facet_counts']['facet_fields']['category']):
+        association = facet[0]
+        category_name = camel_to_snake(re.sub(r'biolink:', '', association))
+        # quote the facet value because of the biolink: prefix
+        association = f'"{association}"'
+        print(association)
+        file = f"{category_name}.all.{output_format}.gz"
+        dump_file_fh = gzip.open(dump_dir / file, 'wt')
+        filters = ['category:{}'.format(association)]
+
+        if output_format == 'tsv':
+            generate_tsv(dump_file_fh, solr_url, filters)
+        elif output_format == 'jsonl':
+            generate_jsonl(dump_file_fh, solr_url, filters)
+
+        logger.info(f"finished writing {file}")
+
+    # Fetch associations configured in config_file
+    conf_fh = open(config_file, 'r')
+    file_filter_map = yaml.safe_load(conf_fh)
+
+    for directory, file_maps in file_filter_map.items():
+        dump_dir = dir_path / directory
+        dump_dir.mkdir(parents=True, exist_ok=True)
+
+        for file, filters in file_maps.items():
+            dump_file = dump_dir / file
+            dump_file_fh = gzip.open(dump_file, 'wt')
+
+            if output_format == 'tsv':
+                generate_tsv(dump_file_fh, solr_url, filters)
+            elif output_format == 'jsonl':
+                generate_jsonl(dump_file_fh, solr_url, filters)
+
+            dump_file_fh.close()
+
+
+def generate_tsv(tsv_fh, solr, filters):
+    default_fields = ','.join([
+            'subject',
+            'subject_label',
+            'subject_taxon',
+            'subject_taxon_label',
+            'negated',
+            'predicate',
+            'object',
+            'object_label',
+            'qualifier'
+            'publications',
+            'has_evidence',
+            'primary_knowledge_source',
+            'aggregator_knowledge_source',
+        ])
+    disease_to_phenotype_extra_fields = ','.join([
+        'onset_qualifier',
+        'onset_qualifier_label',
+        'frequency_qualifier',
+        'frequency_qualifier_label',
+        'sex_qualifier',
+        'sex_qualifier_label'])
+
+    golr_params = {
+        'q': '*:*',
+        'wt': 'csv',
+        'csv.encapsulator': '"',
+        'csv.separator': '\t',
+        'csv.header': 'true',
+        'csv.mv.separator': '|',
+        'fl': default_fields
+    }
+
+    for filter in filters:
+        if filter == 'category:"biolink:DiseaseToPhenotypicFeatureAssociation"':
+            golr_params['fl'] += ',' + disease_to_phenotype_extra_fields
+
+    count_params = {
+        'wt': 'json',
+        'rows': 0,
+        'q': '*:*',
+        'fq': filters,
+    }
+
+    sesh = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(max_retries=10, pool_connections=100, pool_maxsize=100)
+    sesh.mount('https://', adapter)
+    sesh.mount('http://', adapter)
+    solr_request = sesh.get(solr, params=count_params)
+
+    facet_response = None
+    retries = 10
+    resultCount = 0
+    for ret in range(retries):
+        if facet_response:
+            break
+
+        try:
+            facet_response = solr_request.json()
+            resultCount = facet_response['response']['numFound']
+
+            if resultCount == 0:
+                logger.warning("No results found for {}"
+                               " with filters {}".format(tsv_fh.name, filters))
+        except decoder.JSONDecodeError:
+            logger.warning("JSONDecodeError for {}"
+                           " with filters {}".format(tsv_fh.name, filters))
+            logger.warning("solr content: {}".format(solr_request.text))
+            time.sleep(500)
+
+    if not facet_response:
+        logger.error("Could not fetch solr docs with for params %s", filters)
+        exit(1)
+
+    golr_params['rows'] = 5000
+    golr_params['start'] = 0
+    golr_params['fq'] = filters
+
+    first_res = True
+
+    while golr_params['start'] < resultCount:
+        if first_res:
+            golr_params['csv.header'] = 'true'
+            first_res = False
+        else:
+            golr_params['csv.header'] = 'false'
+
+        solr_response = fetch_solr_doc(sesh, solr, golr_params)
+
+        tsv_fh.write(solr_response)
+        golr_params['start'] += golr_params['rows']
+
+    sesh.close()
+
+
+def generate_jsonl(fh, solr, filters):
+
+    #jsonl_writer = jsonlines.open(fh)
+
+    golr_params = {
+        'q': '*:*',
+        'wt': 'json',
+        'fl': '*',
+        'fq': filters,
+        'start': 0,
+        'rows': 5000
+    }
+
+    count_params = {
+        'wt': 'json',
+        'rows': 0,
+        'q': '*:*',
+        'fq': filters,
+    }
+
+    sesh = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(max_retries=10, pool_connections=100, pool_maxsize=100)
+    sesh.mount('https://', adapter)
+    sesh.mount('http://', adapter)
+    solr_request = sesh.get(solr, params=count_params)
+
+    facet_response = None
+    retries = 10
+    resultCount = 0
+    for ret in range(retries):
+        if facet_response:
+            break
+
+        try:
+            facet_response = solr_request.json()
+            resultCount = facet_response['response']['numFound']
+
+            if resultCount == 0:
+                logger.warning("No results found for {}"
+                               " with filters {}".format(fh.name, filters))
+        except decoder.JSONDecodeError:
+            logger.warning("JSONDecodeError for {}"
+                           " with filters {}".format(fh.name, filters))
+            logger.warning("solr content: {}".format(solr_request.text))
+            time.sleep(500)
+
+    if not facet_response:
+        logger.error("Could not fetch solr docs with for params %s", filters)
+        exit(1)
+
+    while golr_params['start'] < resultCount:
+        solr_response = fetch_solr_doc(sesh, solr, golr_params)
+        docs = json.loads(solr_response)['response']['docs']
+        for doc in docs:
+            fh.write(f"{json.dumps(doc)}\n")
+        golr_params['start'] += golr_params['rows']
+
+    sesh.close()
+
+
+def fetch_solr_doc(session, solr, params, retries=10):
+    solr_response = None
+
+    for ret in range(retries):
+        if solr_response:
+            break
+        try:
+            solr_request = session.get(solr, params=params, stream=False)
+            solr_response = solr_request.text
+        except ChunkedEncodingError:
+            logger.warning("ChunkedEncodingError for params %s", params)
+            time.sleep(300)
+
+    if not solr_response:
+        logger.error("Could not fetch solr docs with for params %s", params)
+        exit(1)
+
+    return solr_response
+
+
+def camel_to_snake(name):
+    name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()
+


### PR DESCRIPTION
This brings forward & updates code from the release-utils repo that exported tsv from solr. I'm happy that using the same code is a great way to have consistent structure in the output from the new graph, but it is a little slow, so we may end up rewriting which backend we export the rows from.

