### PR TITLE
Keep all phenio node columns

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -142,11 +142,6 @@ def transform_phenio(
     nodes_df = pandas.read_csv(
         f"data/monarch/{nodefile}", sep="\t", dtype="string", quoting=csv.QUOTE_NONE, lineterminator="\n"
     )
-    nodes_df.drop(
-        nodes_df.columns.difference(["id", "category", "name", "description", "xref", "provided_by", "synonym"]),
-        axis=1,
-        inplace=True,
-    )
     nodes_df = nodes_df[~nodes_df["id"].str.contains("omim.org|hgnc_id")]
     nodes_df = nodes_df[~nodes_df["id"].str.startswith("MGI:")]
 


### PR DESCRIPTION
Allows every node column that comes in via kg-phenio to pass through to the graph. Used to be 100+ columns, now it's a nicely constrained set. The main reason for this change is to allow deprecated in.