### PR TITLE
Update the phenio.db term association population to point to db files in output subdir

### DIFF
--- a/scripts/load_sqlite.sh
+++ b/scripts/load_sqlite.sh
@@ -33,7 +33,7 @@ pigz --force output/monarch-kg-denormalized-edges.tsv
 echo "Populate phenio db term_association..."
 cp data/monarch/phenio.db.gz output/phenio.db.gz
 gunzip output/phenio.db.gz
-sqlite3 -cmd "attach 'monarch-kg.db' as monarch" phenio.db "insert into term_association (id, subject, predicate, object, evidence_type, publication, source) select id, subject, predicate, object, has_evidence as evidence_type, publications as publication, primary_knowledge_source as source from monarch.edges where predicate = 'biolink:has_phenotype' and negated <> 'True'"
+sqlite3 -cmd "attach 'output/monarch-kg.db' as monarch" output/phenio.db "insert into term_association (id, subject, predicate, object, evidence_type, publication, source) select id, subject, predicate, object, has_evidence as evidence_type, publications as publication, primary_knowledge_source as source from monarch.edges where predicate = 'biolink:has_phenotype' and negated <> 'True'"
 
 echo "Compressing databases"
 pigz --force output/phenio.db


### PR DESCRIPTION
We were producing phenio.db files with empty term_association tables, this should fix that