### PR TITLE
Update Reactome ingests to use `Reactome` as a prefix rather than `REACT`

### DIFF
--- a/src/monarch_ingest/ingests/reactome/chemical_to_pathway.py
+++ b/src/monarch_ingest/ingests/reactome/chemical_to_pathway.py
@@ -17,7 +17,7 @@ while (row := koza_app.get_row()) is not None:
     if taxon_id:
 
         chemical_id = "CHEBI:" + row["component"]
-        pathway_id = "REACT:" + row["pathway_id"]  # pathways themselves are an independent ingest now...
+        pathway_id = "Reactome:" + row["pathway_id"]  # pathways themselves are an independent ingest now...
 
         go_evidence_code = row["go_ecode"]
         evidence_code_term = koza_app.translation_table.resolve_term(go_evidence_code)

--- a/src/monarch_ingest/ingests/reactome/gene_to_pathway.py
+++ b/src/monarch_ingest/ingests/reactome/gene_to_pathway.py
@@ -18,7 +18,7 @@ while (row := koza_app.get_row()) is not None:
     if taxon_id:
 
         gene_id = 'NCBIGene:' + row["component"]
-        pathway_id = "REACT:" + row["pathway_id"]  # pathways themselves are an independent ingest now...
+        pathway_id = "Reactome:" + row["pathway_id"]  # pathways themselves are an independent ingest now...
 
         go_evidence_code = row["go_ecode"]
         evidence_code_term = koza_app.translation_table.resolve_term(go_evidence_code)

--- a/src/monarch_ingest/ingests/reactome/pathway.py
+++ b/src/monarch_ingest/ingests/reactome/pathway.py
@@ -15,11 +15,16 @@ while (row := koza_app.get_row()) is not None:
 
     # We only continue of the species is in our local reactome_id_mapping table
     if taxon_id:
+        pathway_id = "Reactome:" + row["ID"]
         pathway = Pathway(
-            id="Reactome:" + row["ID"],
+            id=pathway_id,
             name=row["Name"],
             in_taxon=[taxon_id],
-            provided_by=["infores:reactome"]
+            provided_by=["infores:reactome"],
+
+            # the identifier is duplicated here as a xref to become visible as
+            # an external link in the entity display page of the Monarch App
+            xref=[pathway_id]
         )
 
         koza_app.write(pathway)

--- a/src/monarch_ingest/ingests/reactome/pathway.py
+++ b/src/monarch_ingest/ingests/reactome/pathway.py
@@ -16,7 +16,7 @@ while (row := koza_app.get_row()) is not None:
     # We only continue of the species is in our local reactome_id_mapping table
     if taxon_id:
         pathway = Pathway(
-            id="REACT:" + row["ID"],
+            id="Reactome:" + row["ID"],
             name=row["Name"],
             in_taxon=[taxon_id],
             provided_by=["infores:reactome"]

--- a/tests/unit/reactome/test_reactome_chemical_to_pathway.py
+++ b/tests/unit/reactome/test_reactome_chemical_to_pathway.py
@@ -35,7 +35,7 @@ def test_association(basic_g2p):
     assert association
     assert association.subject == "CHEBI:10033"
     assert association.predicate == "biolink:participates_in"
-    assert association.object == "REACT:R-RNO-6806664"
+    assert association.object == "Reactome:R-RNO-6806664"
     assert "ECO:0000501" in association.has_evidence
     assert association.primary_knowledge_source == "infores:reactome"
     assert "infores:monarchinitiative" in association.aggregator_knowledge_source

--- a/tests/unit/reactome/test_reactome_gene_to_pathway.py
+++ b/tests/unit/reactome/test_reactome_gene_to_pathway.py
@@ -40,7 +40,7 @@ def test_association(basic_g2p):
     assert association
     assert association.subject == "NCBIGene:8627890"
     assert association.predicate == "biolink:participates_in"
-    assert association.object == "REACT:R-DDI-73762"
+    assert association.object == "Reactome:R-DDI-73762"
     assert "ECO:0000501" in association.has_evidence
     assert association.primary_knowledge_source == "infores:reactome"
     assert "infores:monarchinitiative" in association.aggregator_knowledge_source

--- a/tests/unit/reactome/test_reactome_pathway.py
+++ b/tests/unit/reactome/test_reactome_pathway.py
@@ -31,5 +31,5 @@ def basic_g2p(mock_koza, source_name, basic_row, script, global_table, local_tab
 
 def test_pathway_id(basic_g2p):
     pathway = basic_g2p[0]
-    assert pathway.id == "REACT:R-BTA-73843"
+    assert pathway.id == "Reactome:R-BTA-73843"
     assert "infores:reactome" in pathway.provided_by


### PR DESCRIPTION
I don't know that `REACT` is wrong or invalid necessarily, but I know that it's not working with our curie expansion and `Reactome` is, so this seems like a reasonable fix. 