### PR TITLE
Interactions Cleanup

### DIFF
--- a/src/monarch_ingest/ingests/biogrid/biogrid.py
+++ b/src/monarch_ingest/ingests/biogrid/biogrid.py
@@ -14,15 +14,18 @@ while (row := koza_app.get_row()) is not None:
 
     publications = get_publication_ids(row['Publication Identifiers'])
 
-    association = PairwiseGeneToGeneInteraction(
-        id="uuid:" + str(uuid.uuid1()),
-        subject=gid_a,
-        predicate="biolink:interacts_with",
-        object=gid_b,
-        has_evidence=evidence,
-        publications=publications,
-        primary_knowledge_source="infores:biogrid",
-        aggregator_knowledge_source=["infores:monarchinitiative"]
-    )
+    # Only keep interactions using NCBIGene or UniProtKB identifiers, could also filter on taxid
+    if gid_a.startswith("NCBIGene:") or gid_a.startswith("UniProtKB:") \
+            and gid_b.startswith("NCBIGene:") or gid_b.startswith("UniProtKB:"):
+        association = PairwiseGeneToGeneInteraction(
+            id="uuid:" + str(uuid.uuid1()),
+            subject=gid_a,
+            predicate="biolink:interacts_with",
+            object=gid_b,
+            has_evidence=evidence,
+            publications=publications,
+            primary_knowledge_source="infores:biogrid",
+            aggregator_knowledge_source=["infores:monarchinitiative"]
+        )
 
-    koza_app.write(association)
+        koza_app.write(association)

--- a/src/monarch_ingest/ingests/biogrid/biogrid_util.py
+++ b/src/monarch_ingest/ingests/biogrid/biogrid_util.py
@@ -14,7 +14,10 @@ def get_gene_id(raw_id: str) -> str:
     :param raw_id: str, raw BioGRID input string (a pseudo-CURIE)
     :return:
     """
-    gid = raw_id.replace("entrez gene/locuslink", "NCBIGene")
+    gid = (raw_id
+           .replace("entrez gene/locuslink:", "NCBIGene:")
+           .replace("uniprot/swiss-prot:", "UniProtKB:"))
+
     return gid
 
 

--- a/src/monarch_ingest/ingests/string/protein_links.py
+++ b/src/monarch_ingest/ingests/string/protein_links.py
@@ -11,7 +11,12 @@ from string_utils import map_evidence_codes
 
 koza_app = get_koza_app("string_protein_links")
 
-while (row := koza_app.get_row()) is not None:
+seen_rows = set([])
+
+def sorted_id_pair(row) -> str:
+    sorted([row['protein1'], row['protein2']])
+
+while (row := koza_app.get_row()) is not None and sorted_id_pair(row) not in seen_rows:
     
     entrez_2_string = koza_app.get_map('entrez_2_string')
 
@@ -53,7 +58,7 @@ while (row := koza_app.get_row()) is not None:
                     aggregator_knowledge_source=["infores:monarchinitiative"],
                     primary_knowledge_source="infores:string"
                 )
-
+                seen_rows.add(sorted_id_pair(row))
                 entities.append(association)
 
         koza_app.write(*entities)

--- a/tests/unit/string/test_string_protein_links.py
+++ b/tests/unit/string/test_string_protein_links.py
@@ -53,6 +53,34 @@ def basic_row():
         "combined_score": "183",
     }
 
+@pytest.fixture
+def inverse_duplicate_rows():
+    return [
+        {
+            "protein1": "10090.ENSMUSP00000000001",
+            "protein2": "10090.ENSMUSP00000020316",
+            "neighborhood": "0",
+            "fusion": "0",
+            "cooccurence": "0",
+            "coexpression": "116",
+            "experimental": "90",
+            "database": "0",
+            "textmining": "67",
+            "combined_score": "183",
+        },
+        {
+            "protein1": "10090.ENSMUSP00000020316",
+            "protein2": "10090.ENSMUSP00000000001",
+            "neighborhood": "0",
+            "fusion": "0",
+            "cooccurence": "0",
+            "coexpression": "116",
+            "experimental": "90",
+            "database": "0",
+            "textmining": "67",
+            "combined_score": "183",
+        }
+    ]
 
 @pytest.fixture
 def basic_pl(mock_koza, source_name, basic_row, script, global_table, map_cache):
@@ -75,6 +103,26 @@ def basic_pl(mock_koza, source_name, basic_row, script, global_table, map_cache)
         map_cache=map_cache,
     )
 
+@pytest.fixture
+def duplicate_row_entities(mock_koza, source_name, inverse_duplicate_rows, script, global_table, map_cache):
+    """
+    Mock Koza run for STRING protein links ingest.
+
+    :param mock_koza:
+    :param source_name:
+    :param inverse_duplicate_rows:
+    :param script:
+    :param global_table:
+    :param map_cache:
+    :return:
+    """
+    return mock_koza(
+        name=source_name,
+        data=iter(inverse_duplicate_rows),
+        transform_code=script,
+        global_table=global_table,
+        map_cache=map_cache,
+    )
 
 # def test_proteins(basic_pl):
 #     gene_a = basic_pl[0]
@@ -155,3 +203,9 @@ def test_multigene_associations(multigene_entities):
         association for association in multigene_entities if isinstance(association, PairwiseGeneToGeneInteraction)
     ]
     assert len(associations) == 6
+
+def test_duplicates_are_removed(duplicate_row_entities):
+    associations = [
+        association for association in duplicate_row_entities if isinstance(association, PairwiseGeneToGeneInteraction)
+    ]
+    assert len(associations) == 1


### PR DESCRIPTION
Reduce dangling edges for BioGRID by only ingesting genes with prefixes that we reasonably expect we might have
Reduce duplication in StringDB by skipping rows where the same association has already been created in the reverse order
