### PR TITLE
Restore onset_qualifier, plus HPOA DB_reference -> publication and doc cleanup

### DIFF
--- a/docs/Sources/hpoa.md
+++ b/docs/Sources/hpoa.md
@@ -67,7 +67,15 @@ The 'Frequency' field of the aforementioned **phenotypes.hpoa** file has the fol
 
     8. Frequency: There are three allowed options for this field. (A) A term-id from the HPO-sub-ontology below the term “Frequency” (HP:0040279). (since December 2016 ; before was a mixture of values). The terms for frequency are in alignment with Orphanet. * (B) A count of patients affected within a cohort. For instance, 7/13 would indicate that 7 of the 13 patients with the specified disease were found to have the phenotypic abnormality referred to by the HPO term in question in the study referred to by the DB_Reference; (C) A percentage value such as 17%.
 
-The Disease to Phenotype ingest attempts to remap these raw frequency values onto a suitable HPO term.  A simplistic (perhaps erroneous?) assumption is that all such frequencies are conceptually comparable; however, researchers may wish to review the original publications to confirm fitness of purpose of the specific data points to their interpretation - specific values could designate phenotypic frequency at the population level; phenotypic frequency at the cohort level; or simply, be a measure of penetrance of a specific allele within carriers, etc..
+Previously this ingest attempted to map the quantitative frequency values to HPO frequency terms. The only frequency mapping that occurs is between numerical values now, if a fraction is given it will be split into has_count and has_total, and has_quotient will be calculated by division of has_count/has_total, and has_percentage will be calculated by multiplying has_quotient by 100.
+
+__**Reference**__
+
+The phenotype.hpoa format includes a `DB_reference` field described as:
+
+     5. DB_Reference: This required field indicates the source of the information used for the annotation. This may be the clinical experience of the annotator or may be taken from an article as indicated by a PubMed id. Each collaborating center of the Human Phenotype Ontology consortium is assigned a HPO:Ref id. In addition, if appropriate, a PubMed id for an article describing the clinical abnormality may be used.
+
+This ingest preserves values of DB_reference which are not duplicates of the database_id captured as the subject, and will ultimately be found in `original_subject` in the graph when the subject is mapped via SSSOM to a Mondo identifier.
 
 __**Biolink captured**__
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -129,8 +129,8 @@ docs = []
 [package.source]
 type = "git"
 url = "https://github.com/biolink/biolink-model"
-reference = "master"
-resolved_reference = "f1e21a533ec3504d11ad732a2f8b035545b28e78"
+reference = "dc87efc"
+resolved_reference = "dc87efcf374cd80a462d62a9087978bee1e73a4c"
 
 [[package]]
 name = "black"
@@ -3966,4 +3966,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "f15c1da24d5de2362b789b2680a2e30e8799179d546010a93f4997c2e33bcc92"
+content-hash = "78603fc5ad175e67cd88471191136ffd4a6f28e0fef8b9dd3d59d5c6b74d76e5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
-# Monarch & Related Dependencies
-#biolink-model = "^4.1.6"
-biolink-model = { git = "https://github.com/biolink/biolink-model", branch = "master" }
+# biolink-model = "^4.1.7"
+# When 4.1.7 (or any release after 4.1.6) is released, we can remove the git dependency
+biolink-model = { git = "https://github.com/biolink/biolink-model", rev = "dc87efc" }
 bmt = "^1.0.15"
 cat-merge = ">=0.2.0"
 closurizer = "0.5.1"

--- a/src/monarch_ingest/ingests/hpoa/disease_to_phenotype.py
+++ b/src/monarch_ingest/ingests/hpoa/disease_to_phenotype.py
@@ -75,11 +75,9 @@ while (row := koza_app.get_row()) is not None:
     publications_field: str = row["reference"]
     publications: List[str] = publications_field.split(";")
 
-    # Filter out some weird NCBI web endpoints
-    publications = [p for p in publications if not p.startswith("http")]
-
-    # Replace ORPHA prefix with orphanet to match preferred biolink prefix
-    publications = [p.replace("ORPHA:", "orphanet:") for p in publications]
+    # don't populate the reference with the database_id / disease id
+    publications = [p for p in publications
+                    if not p == row["database_id"]]
 
     # Association/Edge
     association = DiseaseToPhenotypicFeatureAssociation(
@@ -91,8 +89,7 @@ while (row := koza_app.get_row()) is not None:
         publications=publications,
         has_evidence=[evidence_curie],
         sex_qualifier=sex_qualifier,
-#  TODO: re-enable once onset_qualifier is on d2p associations in the model
-#        onset_qualifier=onset,
+        onset_qualifier=onset,
         has_percentage=frequency.has_percentage,
         has_quotient=frequency.has_quotient,
         frequency_qualifier=frequency.frequency_qualifier if frequency.frequency_qualifier else None,

--- a/tests/unit/hpoa/test_hpoa_disease_phenotype.py
+++ b/tests/unit/hpoa/test_hpoa_disease_phenotype.py
@@ -39,10 +39,10 @@ def test_disease_to_phenotype_transform_1(d2pf_entities_1):
     assert association.predicate == "biolink:has_phenotype"
     assert association.negated
     assert association.object == "HP:0000343"
-    assert "OMIM:614856" in association.publications
+    assert len(association.publications) == 0
     assert "ECO:0000304" in association.has_evidence  # from local HPOA translation table
     assert association.sex_qualifier == "PATO:0000383"
-#    assert association.onset_qualifier == "HP:0003593"
+    assert association.onset_qualifier == "HP:0003593"
     assert association.has_count == 1
     assert association.has_total == 1
     assert association.has_quotient == 1.0  # '1/1' implies Always present, i.e. in 100% of the cases.
@@ -89,10 +89,10 @@ def test_disease_to_phenotype_transform_2(d2pf_entities_2):
     assert association.predicate == "biolink:has_phenotype"
     assert not association.negated
     assert association.object == "HP:0001249"
-    assert "OMIM:117650" in association.publications
+    assert len(association.publications) == 0
     assert "ECO:0000304" in association.has_evidence  # from local HPOA translation table
     assert not association.sex_qualifier
-#    assert not association.onset_qualifier
+    assert not association.onset_qualifier
     assert association.has_percentage == 50.0  # '50%' implies Present in 30% to 79% of the cases.
     assert association.has_quotient == 0.5
     assert association.frequency_qualifier is None # No implied frequency qualifier based on the '50%' ratio.
@@ -109,7 +109,7 @@ def d2pf_entities_3(mock_koza, global_table):
                 "disease_name": "Cerebrocostomandibular syndrome",
                 "qualifier": "",
                 "hpo_id": "HP:0001545",
-                "reference": "OMIM:117650",
+                "reference": "OMIM:117650;PMID:12345",
                 "evidence": "TAS",
                 "onset": "",
                 "frequency": "HP:0040283",
@@ -137,10 +137,11 @@ def test_disease_to_phenotype_transform_3(d2pf_entities_3):
     assert association.predicate == "biolink:has_phenotype"
     assert not association.negated
     assert association.object == "HP:0001545"
-    assert "OMIM:117650" in association.publications
+    assert len(association.publications) == 1
+    assert "PMID:12345" in association.publications
     assert "ECO:0000304" in association.has_evidence  # from local HPOA translation table
     assert not association.sex_qualifier
-#    assert not association.onset_qualifier
+    assert not association.onset_qualifier
     assert association.has_count is None
     assert association.has_total is None
     assert association.has_percentage is None


### PR DESCRIPTION
- No longer populating publications column with reference value if it's the same as database_id, populating the NCBI urls (will likely require some UI handling). Populating onset qualifier again via a biolink git dependency.
- Documentation update to match code changes
