### PR TITLE
Populate type for HGNC & Alliance gene nodes

### DIFF
--- a/docs/Sources/alliance.md
+++ b/docs/Sources/alliance.md
@@ -19,6 +19,8 @@ __**Biolink captured**__
     * source
     * synonyms
     * xref
+    * type (["SO:0001217"])
+
 
 ## [Gene to Phenotype](#gene_to_phenotype)
 

--- a/docs/Sources/hgnc.md
+++ b/docs/Sources/hgnc.md
@@ -8,6 +8,8 @@ The HGNC is responsible for approving unique symbols and names for human loci, i
 
 This ingest uses HGNC's "complete set" download file, which only contains associations between publications and genes that are denoted in some way in the publication. We have selected to use a consistent high level term for 'publication' (IAO:0000311) as it is heterogeneous mix of publication types being referenced. 
 
+SO terms to populate the type are taken from the Alliance genome HGNC BGI files, provided by RGD.
+
 __**Biolink Captured**__
 
 * biolink:Gene
@@ -24,6 +26,7 @@ __**Biolink Captured**__
       * omim id
     * in_taxon (["NCBITaxon:9606"])
     * provided_by  (["infores:hgnc"])
+    * type (["SO:0001217"])
 
 ## Citation
 

--- a/scripts/after_download.sh
+++ b/scripts/after_download.sh
@@ -3,16 +3,16 @@
 # set zcat to gzcat if gzcat is available
 if command -v gzcat &> /dev/null
 then
-    zcat=gzcat
+    ZCAT=gzcat
 else
-    zcat=zcat
+    ZCAT=zcat
 fi
 
 # Make a simple text file of all the gene IDs in Alliance
-zcat data/alliance/BGI_*.gz | jq '.data[].basicGeneticEntity.primaryId' | pigz > data/alliance/alliance_gene_ids.txt.gz
+${ZCAT} data/alliance/BGI_*.gz | jq '.data[].basicGeneticEntity.primaryId' | pigz > data/alliance/alliance_gene_ids.txt.gz
 
 # Make a two column tsv of human gene IDs and SO terms
-zcat data/alliance/BGI_HUMAN.json.gz |  jq -r '.data[] | "\(.basicGeneticEntity.primaryId)\t\(.soTermId)"' > data/hgnc/hgnc_so_terms.tsv
+${ZCAT} data/alliance/BGI_HUMAN.json.gz |  jq -r '.data[] | "\(.basicGeneticEntity.primaryId)\t\(.soTermId)"' > data/hgnc/hgnc_so_terms.tsv
 
 # Make an id, name map of DDPHENO terms
 sqlite3 -cmd ".mode tabs" -cmd ".headers on" data/dictybase/ddpheno.db "select subject as id, value as name from rdfs_label_statement where predicate = 'rdfs:label' and subject like 'DDPHENO:%'" > data/dictybase/ddpheno.tsv

--- a/scripts/after_download.sh
+++ b/scripts/after_download.sh
@@ -1,7 +1,18 @@
 #!/bin/sh
 
+# set zcat to gzcat if gzcat is available
+if command -v gzcat &> /dev/null
+then
+    zcat=gzcat
+else
+    zcat=zcat
+fi
+
 # Make a simple text file of all the gene IDs in Alliance
 zcat data/alliance/BGI_*.gz | jq '.data[].basicGeneticEntity.primaryId' | pigz > data/alliance/alliance_gene_ids.txt.gz
+
+# Make a two column tsv of human gene IDs and SO terms
+zcat data/alliance/BGI_HUMAN.json.gz |  jq -r '.data[] | "\(.basicGeneticEntity.primaryId)\t\(.soTermId)"' > data/hgnc/hgnc_so_terms.tsv
 
 # Make an id, name map of DDPHENO terms
 sqlite3 -cmd ".mode tabs" -cmd ".headers on" data/dictybase/ddpheno.db "select subject as id, value as name from rdfs_label_statement where predicate = 'rdfs:label' and subject like 'DDPHENO:%'" > data/dictybase/ddpheno.tsv

--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -1,5 +1,4 @@
 import csv
-import gc
 import os
 import sys
 import tarfile
@@ -407,12 +406,13 @@ def apply_closure(
     )
     sh.mv(database, f"{output_dir}/")
 
+
 def load_sqlite():
     sh.bash("scripts/load_sqlite.sh")
 
 
 def load_solr():
-    sh.bash("scripts/load_solr.sh",  _out=sys.stdout, _err=sys.stderr)
+    sh.bash("scripts/load_solr.sh", _out=sys.stdout, _err=sys.stderr)
 
 
 def load_jsonl():
@@ -446,25 +446,30 @@ def load_jsonl():
     mv_node_replacement = ", ".join([f"string_split({col}, '|') as {col}" for col in mv_node_columns])
     mv_edge_replacement = ", ".join([f"string_split({col}, '|') as {col}" for col in mv_edge_columns])
 
-    db.sql(f"""
+    db.sql(
+        f"""
     copy (
       select nodes.* replace (ancestors as category, {mv_node_replacement}) 
       from nodes
         join class_ancestor_df on category = classname  
     ) to 'output/monarch-kg_nodes.jsonl' (FORMAT JSON);
-    """)
+    """
+    )
 
-    db.sql(f"""
+    db.sql(
+        f"""
     copy (
       select edges.* replace (ancestors as category, {mv_edge_replacement}),  
       from edges
         join class_ancestor_df on category = classname  
     ) to 'output/monarch-kg_edges.jsonl' (FORMAT JSON);
-    """)
+    """
+    )
 
 
 def export_tsv():
     export()
+
 
 def do_prepare_release(dir: str = OUTPUT_DIR):
 

--- a/src/monarch_ingest/download.yaml
+++ b/src/monarch_ingest/download.yaml
@@ -49,6 +49,10 @@
   local_name: data/alliance/GENECROSSREFERENCE_COMBINED.tsv.gz
   tag: alliance_gene
 -
+  url: https://fms.alliancegenome.org/download/BGI_HUMAN.json.gz
+  local_name: data/alliance/BGI_HUMAN.json.gz
+  tag: hgnc_gene
+-
   url: https://fms.alliancegenome.org/download/BGI_MGI.json.gz
   local_name: data/alliance/BGI_MGI.json.gz
   tag: alliance_gene

--- a/src/monarch_ingest/ingests/alliance/gene.py
+++ b/src/monarch_ingest/ingests/alliance/gene.py
@@ -49,8 +49,7 @@ while (row := koza_app.get_row()) is not None:
         symbol=row["symbol"],
         name=row["symbol"],
         full_name=row["name"].replace("\r", ""),  # Replacement to remove stray carriage returns in XenBase files
-        # No place in the schema for gene type (SO term) right now
-        # type=row["soTermId"],
+        type=[row["soTermId"]],
         in_taxon=[in_taxon],
         in_taxon_label=in_taxon_label,
         provided_by=[source],

--- a/src/monarch_ingest/ingests/alliance/gene.yaml
+++ b/src/monarch_ingest/ingests/alliance/gene.yaml
@@ -34,6 +34,7 @@ node_properties:
   - 'provided_by'
   - 'name'
   - 'symbol'
+  - 'type'
   - 'full_name'
   - 'description'
   - 'in_taxon'

--- a/src/monarch_ingest/ingests/alliance/gene_to_phenotype.py
+++ b/src/monarch_ingest/ingests/alliance/gene_to_phenotype.py
@@ -16,9 +16,9 @@ from loguru import logger
 
 koza_app = get_koza_app("alliance_gene_to_phenotype")
 
-while (row := koza_app.get_row()) is not None:
+gene_ids = koza_app.get_map("alliance-gene")
 
-    gene_ids = koza_app.get_map("alliance-gene")
+while (row := koza_app.get_row()) is not None:
 
     if len(row["phenotypeTermIdentifiers"]) == 0:
         logger.debug("Phenotype ingest record has 0 phenotype terms: " + str(row))

--- a/src/monarch_ingest/ingests/hgnc/gene.py
+++ b/src/monarch_ingest/ingests/hgnc/gene.py
@@ -4,6 +4,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import Gene
 
 koza_app = get_koza_app("hgnc_gene")
 
+so_term_map = koza_app.get_map("hgnc-so-terms")
+
 while (row := koza_app.get_row()) is not None:
 
     xref_list = []
@@ -31,6 +33,7 @@ while (row := koza_app.get_row()) is not None:
         symbol=row["symbol"],
         name=row["symbol"],
         full_name=row["name"],
+        type=[so_term_map[row['hgnc_id']]['so_term_id']] if row['hgnc_id'] in so_term_map else None,
         xref=xref_list,
         synonym=synonyms_list,
         in_taxon=[in_taxon],

--- a/src/monarch_ingest/ingests/hgnc/gene.yaml
+++ b/src/monarch_ingest/ingests/hgnc/gene.yaml
@@ -9,6 +9,9 @@ delimiter: '\t'
 
 global_table: './src/monarch_ingest/translation_table.yaml'
 
+depends_on:
+  - './src/monarch_ingest/maps/hgnc-so-terms.yaml'
+
 columns:
   - hgnc_id
   - symbol
@@ -73,6 +76,7 @@ node_properties:
   - 'full_name'
   - 'in_taxon'
   - 'in_taxon_label'
+  - 'type'
   - 'xref'
   - 'synonym'
   - 'provided_by'

--- a/src/monarch_ingest/ingests/hpoa/disease_to_phenotype.py
+++ b/src/monarch_ingest/ingests/hpoa/disease_to_phenotype.py
@@ -37,6 +37,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
 )
 from monarch_ingest.ingests.hpoa.hpoa_utils import phenotype_frequency_to_hpo_term, Frequency
 
+
 def get_primary_knowledge_source(disease_id: str) -> str:
     if disease_id.startswith("OMIM"):
         return "infores:omim"
@@ -90,7 +91,7 @@ while (row := koza_app.get_row()) is not None:
     # don't populate the reference with the database_id / disease id
     publications = [p for p in publications if not p == row["database_id"]]
 
-    primary_knowledge_source = get_primary_knowledge_source(disease_id )
+    primary_knowledge_source = get_primary_knowledge_source(disease_id)
 
     # Association/Edge
     association = DiseaseToPhenotypicFeatureAssociation(
@@ -108,7 +109,7 @@ while (row := koza_app.get_row()) is not None:
         frequency_qualifier=frequency.frequency_qualifier if frequency.frequency_qualifier else None,
         has_count=frequency.has_count,
         has_total=frequency.has_total,
-        aggregator_knowledge_source=["infores:monarchinitiative","infores:hpo-annotations"],
+        aggregator_knowledge_source=["infores:monarchinitiative", "infores:hpo-annotations"],
         primary_knowledge_source=primary_knowledge_source,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,

--- a/src/monarch_ingest/main.py
+++ b/src/monarch_ingest/main.py
@@ -164,9 +164,11 @@ def solr():
 def export():
     export_tsv()
 
+
 @typer_app.command()
 def prepare_release():
-    do_prepare_release();
+    do_prepare_release()
+
 
 @typer_app.command()
 def release(

--- a/src/monarch_ingest/maps/hgnc-so-terms.yaml
+++ b/src/monarch_ingest/maps/hgnc-so-terms.yaml
@@ -1,0 +1,22 @@
+name: 'hgnc-so-terms'
+
+metadata:
+  description: 'Mapping file to look up SO terms (aka type) for HGNC genes, generated from Alliance BGI files and provided by RGD'
+
+delimiter: '\t'
+
+files:
+  - './data/hgnc/hgnc_so_terms.tsv'
+
+header: 'none'
+
+columns:
+  - 'gene_id'
+  - 'so_term_id'
+
+key: 'gene_id'
+
+values:
+  - 'gene_id'
+  - 'so_term_id'
+

--- a/tests/unit/alliance/test_alliance_gene.py
+++ b/tests/unit/alliance/test_alliance_gene.py
@@ -203,6 +203,10 @@ def test_gene_information_id(pax2a):
     gene = pax2a[0]
     assert gene.id == "ZFIN:ZDB-GENE-990415-8"
 
+def test_gene_information_type(pax2a):
+    gene = pax2a[0]
+    assert gene.type
+    assert gene.type == ["SO:0001217"]
 
 def test_gene_information_no_synonyms(no_synonym_gene):
     gene = no_synonym_gene[0]
@@ -213,3 +217,4 @@ def test_gene_information_no_name_gene_uses_symbol(no_name_gene):
     gene = no_name_gene[0]
     assert gene
     assert gene.name == gene.symbol
+

--- a/tests/unit/alliance/test_alliance_gene.py
+++ b/tests/unit/alliance/test_alliance_gene.py
@@ -203,10 +203,12 @@ def test_gene_information_id(pax2a):
     gene = pax2a[0]
     assert gene.id == "ZFIN:ZDB-GENE-990415-8"
 
+
 def test_gene_information_type(pax2a):
     gene = pax2a[0]
     assert gene.type
     assert gene.type == ["SO:0001217"]
+
 
 def test_gene_information_no_synonyms(no_synonym_gene):
     gene = no_synonym_gene[0]
@@ -217,4 +219,3 @@ def test_gene_information_no_name_gene_uses_symbol(no_name_gene):
     gene = no_name_gene[0]
     assert gene
     assert gene.name == gene.symbol
-

--- a/tests/unit/hgnc/test_hgnc_gene.py
+++ b/tests/unit/hgnc/test_hgnc_gene.py
@@ -27,15 +27,22 @@ def gene_row():
         "prev_name": "",
     }
 
+@pytest.fixture
+def so_term_map_cache():
+    return {
+        "hgnc-so-terms": {
+            "HGNC:24086": {"so_term_id": "SO:0001217"}
+        }
+    }
 
 @pytest.fixture
-def pax2a(mock_koza, source_name, gene_row, script, taxon_label_map_cache, global_table):
+def pax2a(mock_koza, source_name, gene_row, script, taxon_label_map_cache, so_term_map_cache, global_table):
     row = gene_row
     return mock_koza(
         source_name,
         row,
         script,
-        map_cache=taxon_label_map_cache,
+        map_cache=taxon_label_map_cache | so_term_map_cache,
         global_table=global_table,
     )
 
@@ -57,6 +64,10 @@ def test_gene_information_xref(pax2a):
     assert gene.xref
     assert gene.xref == ["ENSEMBL:ENSG00000148584", "OMIM:618199"]
 
+def test_gene_information_so_term(pax2a):
+    gene = pax2a[0]
+    assert gene.type
+    assert gene.type == ["SO:0001217"]
 
 # Commenting out publication ingests at least temporarily
 # def test_publication(pax2a):

--- a/tests/unit/hgnc/test_hgnc_gene.py
+++ b/tests/unit/hgnc/test_hgnc_gene.py
@@ -27,13 +27,11 @@ def gene_row():
         "prev_name": "",
     }
 
+
 @pytest.fixture
 def so_term_map_cache():
-    return {
-        "hgnc-so-terms": {
-            "HGNC:24086": {"so_term_id": "SO:0001217"}
-        }
-    }
+    return {"hgnc-so-terms": {"HGNC:24086": {"so_term_id": "SO:0001217"}}}
+
 
 @pytest.fixture
 def pax2a(mock_koza, source_name, gene_row, script, taxon_label_map_cache, so_term_map_cache, global_table):
@@ -64,10 +62,12 @@ def test_gene_information_xref(pax2a):
     assert gene.xref
     assert gene.xref == ["ENSEMBL:ENSG00000148584", "OMIM:618199"]
 
+
 def test_gene_information_so_term(pax2a):
     gene = pax2a[0]
     assert gene.type
     assert gene.type == ["SO:0001217"]
+
 
 # Commenting out publication ingests at least temporarily
 # def test_publication(pax2a):

--- a/tests/unit/hpoa/test_hpoa_disease_phenotype.py
+++ b/tests/unit/hpoa/test_hpoa_disease_phenotype.py
@@ -46,7 +46,7 @@ def test_disease_to_phenotype_transform_1(d2pf_entities_1):
     assert association.has_percentage == 100.0
     assert association.frequency_qualifier is None  # No implied frequency qualifier based on the '1/1' ratio.
     assert association.primary_knowledge_source == "infores:omim"
-    assert association.aggregator_knowledge_source == ["infores:monarchinitiative","infores:hpo-annotations"]
+    assert association.aggregator_knowledge_source == ["infores:monarchinitiative", "infores:hpo-annotations"]
 
 
 @pytest.fixture
@@ -90,7 +90,7 @@ def test_disease_to_phenotype_transform_2(d2pf_entities_2):
     assert association.has_quotient == 0.5
     assert association.frequency_qualifier is None  # No implied frequency qualifier based on the '50%' ratio.
     assert association.primary_knowledge_source == "infores:omim"
-    assert association.aggregator_knowledge_source == ["infores:monarchinitiative","infores:hpo-annotations"]
+    assert association.aggregator_knowledge_source == ["infores:monarchinitiative", "infores:hpo-annotations"]
 
 
 @pytest.fixture
@@ -137,8 +137,7 @@ def test_disease_to_phenotype_transform_3(d2pf_entities_3):
     assert association.has_quotient is None
     assert association.frequency_qualifier == "HP:0040283"  # "HP:0040283" implies Present in 5% to 29% of the cases.
     assert association.primary_knowledge_source == "infores:omim"
-    assert association.aggregator_knowledge_source == ["infores:monarchinitiative","infores:hpo-annotations"]
-
+    assert association.aggregator_knowledge_source == ["infores:monarchinitiative", "infores:hpo-annotations"]
 
 
 @pytest.fixture
@@ -182,7 +181,20 @@ def test_disease_to_phenotype_transform_frequency_fraction(d2pf_frequency_fracti
 
 @pytest.fixture
 def count_zero_entities(mock_koza, global_table):
-    row = {'database_id': 'OMIM:615654', 'disease_name': 'Deafness, autosomal dominant 58', 'qualifier': '', 'hpo_id': 'HP:0007663', 'reference': 'PMID:32337552', 'evidence': 'PCS', 'onset': '', 'frequency': '0/20', 'sex': '', 'modifier': '', 'aspect': 'P', 'biocuration': 'HPO:probinson[2024-03-15];HPO:probinson[2024-03-15]'}
+    row = {
+        'database_id': 'OMIM:615654',
+        'disease_name': 'Deafness, autosomal dominant 58',
+        'qualifier': '',
+        'hpo_id': 'HP:0007663',
+        'reference': 'PMID:32337552',
+        'evidence': 'PCS',
+        'onset': '',
+        'frequency': '0/20',
+        'sex': '',
+        'modifier': '',
+        'aspect': 'P',
+        'biocuration': 'HPO:probinson[2024-03-15];HPO:probinson[2024-03-15]',
+    }
 
     return mock_koza(
         name="hpoa_disease_to_phenotype",
@@ -203,7 +215,20 @@ def test_zero_fraction(count_zero_entities):
 
 @pytest.fixture
 def orphanet_entities(mock_koza, global_table):
-    row = {'database_id': 'ORPHA:79474', 'disease_name': 'Atypical Werner syndrome', 'qualifier': '', 'hpo_id': 'HP:0000347', 'reference': 'ORPHA:79474', 'evidence': 'TAS', 'onset': '', 'frequency': 'HP:0040281', 'sex': '', 'modifier': '', 'aspect': 'P', 'biocuration': 'ORPHA:orphadata[2024-06-25]'}
+    row = {
+        'database_id': 'ORPHA:79474',
+        'disease_name': 'Atypical Werner syndrome',
+        'qualifier': '',
+        'hpo_id': 'HP:0000347',
+        'reference': 'ORPHA:79474',
+        'evidence': 'TAS',
+        'onset': '',
+        'frequency': 'HP:0040281',
+        'sex': '',
+        'modifier': '',
+        'aspect': 'P',
+        'biocuration': 'ORPHA:orphadata[2024-06-25]',
+    }
     return mock_koza(
         name="hpoa_disease_to_phenotype",
         data=[row],
@@ -211,6 +236,7 @@ def orphanet_entities(mock_koza, global_table):
         global_table=global_table,
         local_table="./src/monarch_ingest/ingests/hpoa/hpoa-translation.yaml",
     )
+
 
 def test_orphanet_entities(orphanet_entities):
     entities = orphanet_entities


### PR DESCRIPTION
Adds a lookup table for HGNC to SO term ID to populate the biolink type field for human genes. Also enables the type field for Alliance genes, which was commented out previously. Plus tests.**

Additionally, there are some unrelated formatting changes that came in as well.

Fixes #649

Update to add: The alternate approach would be to create a mapping table from the type strings provided by HGNC directly which in retrospect does sound like it's a little more maintainable. I'm open to rolling this back and going that way instead.  
