### PR TITLE
Load neo4j with csv rather than kgx

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,11 @@ pipeline {
                 sh 'poetry run ingest jsonl'
             }
         }
+        stage('neo4j-csv') {
+            steps {
+                sh 'poetry run ingest neo4j-csv'
+            }
+        }
         stage('solr') {
             steps {
                 sh 'poetry run ingest solr'

--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -421,9 +421,7 @@ def load_solr():
     sh.bash("scripts/load_solr.sh", _out=sys.stdout, _err=sys.stderr)
 
 
-def load_jsonl():
-    db = duckdb.connect('output/monarch-kg.duckdb')
-
+def get_biolink_ancestor_df():
     biolink_model = SchemaView(
         f"https://raw.githubusercontent.com/biolink/biolink-model/v{model.version}/biolink-model.yaml"
     )
@@ -434,9 +432,16 @@ def load_jsonl():
             f"biolink:{camelcase(a)}" for a in biolink_model.class_ancestors(c.name)
         ]
     all_slot_names = biolink_model.all_slots().keys()
-
-    # this may appear to be unused, but it's accessed in the duckdb sql queries below
+    
     class_ancestor_df = pandas.DataFrame(list(class_ancestor_dict.items()), columns=['classname', 'ancestors'])
+
+    return class_ancestor_df, all_slot_names, biolink_model
+
+
+def load_jsonl():
+    db = duckdb.connect('output/monarch-kg.duckdb')
+
+    class_ancestor_df, all_slot_names, biolink_model = get_biolink_ancestor_df()
 
     node_columns = db.sql("PRAGMA table_info(nodes);").df()["name"].to_list()
     edge_columns = db.sql("PRAGMA table_info(edges);").df()["name"].to_list()
@@ -471,6 +476,70 @@ def load_jsonl():
     ) to 'output/monarch-kg_edges.jsonl' (FORMAT JSON);
     """
     )
+
+
+def load_neo4j_csv():
+    """
+    Create CSV files for Neo4j import from the DuckDB database.
+    This function exports nodes and edges to CSV files in the output directory.
+    """
+    db = duckdb.connect('output/monarch-kg.duckdb', read_only=True)
+
+    node_columns = db.sql("PRAGMA table_info(nodes);").df()["name"].to_list()
+    edge_columns = db.sql("PRAGMA table_info(edges);").df()["name"].to_list()
+
+    class_ancestor_df, all_slot_names, biolink_model = get_biolink_ancestor_df()
+
+    def slot_is_multi_valued(slot_name: str) -> bool:
+        slot_name = slot_name.lower().replace("_", " ")
+        if slot_name not in all_slot_names:
+            return False
+        return biolink_model.get_slot(slot_name).multivalued
+        
+    mv_node_columns = [col for col in node_columns if slot_is_multi_valued(col) and col != "category"]
+    mv_edge_columns = [col for col in edge_columns if slot_is_multi_valued(col) and col != "category"]
+    mv_node_replacement = ", ".join([f"replace({col}, '|', ';') as {col}" for col in mv_node_columns])
+    mv_edge_replacement = ", ".join([f"replace({col}, '|', ';') as {col}" for col in mv_edge_columns])
+
+        # also write to neo4j csv format 
+    edges_query = f"""
+    copy (
+        select
+            id,
+            array_to_string(ancestors,';') as category,
+            subject as "subject:START_ID", 
+            predicate as "predicate:TYPE",
+            object as "object:END_ID",
+            edges.*
+              EXCLUDE (id, category, subject, predicate, object) 
+              REPLACE(                                
+                {mv_edge_replacement}
+              )                        
+        from edges 
+          join class_ancestor_df on category = classname  
+    ) to 'output/monarch-kg_edges.neo4j.csv'
+    """
+    db.sql(edges_query)
+
+    nodes_query = f"""
+    copy (
+        select
+            id as "id:ID",            
+            array_to_string(ancestors,';') as "category:LABEL",
+            nodes.*
+              EXCLUDE(id, category)
+              REPLACE(
+                {mv_node_replacement}
+              )
+        from nodes
+          join class_ancestor_df on category = classname
+    ) to 'output/monarch-kg_nodes.neo4j.csv'
+    """
+    db.sql(nodes_query)
+
+    print(edges_query)
+    print(nodes_query)
+    
 
 
 def create_qc_reports():

--- a/src/monarch_ingest/main.py
+++ b/src/monarch_ingest/main.py
@@ -12,6 +12,7 @@ from monarch_ingest.cli_utils import (
     get_data_versions,
     get_pkg_versions,
     load_jsonl,
+    load_neo4j_csv,
     load_sqlite,
     load_solr,
     merge_files,
@@ -171,6 +172,10 @@ def closure():
 @typer_app.command()
 def jsonl():
     load_jsonl()
+
+@typer_app.command()
+def neo4j_csv():
+    load_neo4j_csv()    
 
 
 @typer_app.command()


### PR DESCRIPTION
Let's try using csv loading to populate neo4j. We're getting 4m fewer edges when we load with kgx, and we're not yet sure why. It's also a bit slow.
