### PR TITLE
Update PomBase gene ingest for renamed external_id column

### DIFF
--- a/src/monarch_ingest/ingests/pombase/gene.py
+++ b/src/monarch_ingest/ingests/pombase/gene.py
@@ -23,8 +23,8 @@ def transform_record(koza_transform, row):
         provided_by=["infores:pombase"],
     )
 
-    if row["uniprot_id"]:
-        gene.xref = ["UniProtKB:" + row["uniprot_id"]]
+    if row["external_id"]:
+        gene.xref = ["UniProtKB:" + row["external_id"]]
 
     if row["synonyms"]:
         gene.synonym = row["synonyms"].split(",")

--- a/src/monarch_ingest/ingests/pombase/gene.yaml
+++ b/src/monarch_ingest/ingests/pombase/gene.yaml
@@ -17,7 +17,7 @@ reader:
     - "gene_name"
     - "chromosome_id"
     - "gene_product"
-    - "uniprot_id"
+    - "external_id"
     - "gene_type"
     - "synonyms"
 

--- a/tests/unit/pombase/test_pombase_gene.py
+++ b/tests/unit/pombase/test_pombase_gene.py
@@ -14,7 +14,7 @@ def gene_information_entities():
         'gene_name': 'bqt2',
         'chromosome_id': 'chromosome_1',
         'gene_product': 'bouquet formation protein Bqt2',
-        'uniprot_id': 'Q9US52',
+        'external_id': 'Q9US52',
         'gene type': 'protein coding gene',
         'synonyms': 'mug18,rec23',
     }
@@ -30,7 +30,7 @@ def gene_entity_no_name():
         'gene_name': '',
         'chromosome_id': 'chromosome_1',
         'gene_product': 'bouquet formation protein Bqt2',
-        'uniprot_id': 'Q9US52',
+        'external_id': 'Q9US52',
         'gene type': 'protein coding gene',
         'synonyms': 'mug18,rec23',
     }


### PR DESCRIPTION
## Summary
- Updated PomBase gene ingest to handle renamed column in upstream data file
- Column `uniprot_id` → `external_id` in gene_IDs_names_products.tsv
- The new column name supports multiple external ID types (UniProt for protein-coding genes, RNAcentral for non-coding RNAs)
- Since we filter to only protein-coding genes, all IDs remain UniProt IDs with the `UniProtKB:` prefix

## Changes
- Updated `gene.yaml` column configuration
- Updated `gene.py` transform code to reference new column name  
- Updated test fixtures in `test_pombase_gene.py`

## Test plan
- [x] Transform runs successfully: `poetry run ingest transform -i pombase_gene` (processed 12,685 rows)
- [x] All unit tests pass: `poetry run pytest tests/unit/pombase/test_pombase_gene.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)