### PR TITLE
Add Ingest Principles overview page

### DIFF
--- a/docs/Principles/index.md
+++ b/docs/Principles/index.md
@@ -1,0 +1,19 @@
+# Ingest Principles
+
+## Overview
+
+The Monarch Knowledge Graph (KG) is built from a variety of data sources in the biomedical domain.
+These data sources are "ingested" into the KG using a variety of tools and packages created by the Monarch Initiative team and our collaborators.
+This page describes the principles that guide the ingestion process.
+
+A list of all data sources ingested into the KG can be found [here](../Sources/index.md).
+
+## General Principles
+
+1. All ingests should have a stringent (defensive) filtering strategy.
+
+1. Utilize Biolink profiles to inform the filtering of incoming ingests (ex. Phenio)
+
+1. Use yaml to implement this
+
+1. All nodes should have a category attached.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -15,7 +15,9 @@ nav:
     - Implement: 'Create-an-Ingest/4. Implement.md'
     - Testing: 'Create-an-Ingest/5. Test.md'
   - KG Build Process: 'KG-Build-Process/kg-build-process.md'
-  - Principles: 'Principles/modeling-principles.md'
+  - Principles:
+    - Overview: 'Principles/index.md'
+    - Modeling Principles: 'Principles/modeling-principles.md'
   - Sources:
     - Overview: 'Sources/index.md'
     - Alliance: 'Sources/alliance.md'


### PR DESCRIPTION
## Summary
- Adds overview content and general principles to the Principles section
- Updates navigation to show Principles as a section with Overview and Modeling Principles sub-pages
- Content moved from monarch-documentation repository

Resolves monarch-initiative/monarch-documentation#70

## Test plan
- [ ] Build docs locally and verify the Principles section renders correctly
- [ ] Verify navigation shows both Overview and Modeling Principles pages

🤖 Generated with [Claude Code](https://claude.ai/claude-code)