### PR TITLE
Add phenopacket-ingest as modular ingest

### DIFF
--- a/src/monarch_ingest/ingests.yaml
+++ b/src/monarch_ingest/ingests.yaml
@@ -100,3 +100,7 @@ zfin_orthology:
 omim_gene_to_disease:
   url:
     - 'https://github.com/monarch-initiative/omim-ingest/releases/latest/download/omim_gene_to_disease_edges.tsv'
+phenopacket_ingest:
+  url:
+    - 'https://github.com/monarch-initiative/phenopacket-ingest/releases/latest/download/phenopacket_ingest_nodes.tsv'
+    - 'https://github.com/monarch-initiative/phenopacket-ingest/releases/latest/download/phenopacket_ingest_edges.tsv'

--- a/src/monarch_ingest/qc_expect.yaml
+++ b/src/monarch_ingest/qc_expect.yaml
@@ -31,6 +31,8 @@ nodes:
       min: 7000
     clingen_variant_nodes:
       min: 5600
+    phenopacket_ingest_nodes:
+      min: 8000
 edges:
   provided_by:
     alliance_gene_to_expression_edges:
@@ -90,4 +92,6 @@ edges:
       min: 5000
     omim_gene_to_disease_edges:
       min: 7500
+    phenopacket_ingest_edges:
+      min: 180000
 


### PR DESCRIPTION
## Summary
- Adds phenopacket-ingest as a pass-through modular ingest
- Downloads nodes and edges from phenopacket-ingest releases
- Adds QC expectations for nodes (min: 8,000) and edges (min: 180,000)

## Data Overview
This ingest provides Case nodes linked to:
- **Diseases**: Case → OMIM (mapped to MONDO via SSSOM)
- **Genes**: Case → HGNC  
- **Phenotypes**: Case → HP

Current counts after merge:
- Nodes: 8,207
- Edges: 184,609

## Dependencies
Requires the edge ID fix in phenopacket-ingest (merged in monarch-initiative/phenopacket-ingest@9babfdd)

## Test plan
- [x] Ran `ingest transform -i phenopacket_ingest` to download latest release
- [x] Ran `ingest merge` to verify edges are correctly merged
- [x] Verified 184,609 edges in final KG (up from 8,207 before ID fix)
- [x] Confirmed QC expectations pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)