### PR TITLE
Add Neo4j v5 dump alongside existing v4 dump

### DIFF
--- a/scripts/load_neo4j.sh
+++ b/scripts/load_neo4j.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-echo "Building Neo4j Artifact"
+echo "Building Neo4j Artifacts"
 
-mkdir neo4j_data || True
-rm -rf neo4j_data/* || True
-rm -rf output/monarch-kg.neo4j.dump || True
-
+# Neo4j v4 dump
+echo "Building Neo4j v4 dump..."
+mkdir -p neo4j_data_v4
+rm -rf neo4j_data_v4/*
+rm -f output/monarch-kg.neo4j.dump
 
 docker run --rm \
   -v $(pwd)/output:/import \
-  -v $(pwd)/neo4j_data:/data \
+  -v $(pwd)/neo4j_data_v4:/data \
   neo4j:4.4 \
   neo4j-admin import \
   --force \
@@ -17,4 +18,33 @@ docker run --rm \
   --nodes=/import/monarch-kg_nodes.neo4j.csv \
   --relationships=/import/monarch-kg_edges.neo4j.csv
 
-docker run -v $(pwd)/output:/backup -v $(pwd)/neo4j_data:/data --entrypoint neo4j-admin neo4j:4.4 dump --to /backup/monarch-kg.neo4j.dump
+docker run --rm \
+  -v $(pwd)/output:/backup \
+  -v $(pwd)/neo4j_data_v4:/data \
+  --entrypoint neo4j-admin \
+  neo4j:4.4 dump --to /backup/monarch-kg.neo4j.dump
+
+# Neo4j v5 dump
+echo "Building Neo4j v5 dump..."
+mkdir -p neo4j_data_v5
+rm -rf neo4j_data_v5/*
+rm -f output/monarch-kg.neo4j.v5.dump
+
+docker run --rm \
+  -v $(pwd)/output:/import \
+  -v $(pwd)/neo4j_data_v5:/data \
+  neo4j:5 \
+  neo4j-admin database import full \
+  --overwrite-destination=true \
+  --nodes=/import/monarch-kg_nodes.neo4j.csv \
+  --relationships=/import/monarch-kg_edges.neo4j.csv
+
+docker run --rm \
+  -v $(pwd)/output:/dump \
+  -v $(pwd)/neo4j_data_v5:/data \
+  --entrypoint neo4j-admin \
+  neo4j:5 database dump --to-path=/dump neo4j
+
+mv output/neo4j.dump output/monarch-kg.neo4j.v5.dump
+
+echo "Done building Neo4j artifacts"


### PR DESCRIPTION
## Summary
- Update build process to produce both Neo4j v4 and v5 database dumps
- Reuses the same CSV files, just runs the import/dump process twice with different Neo4j versions
- v4 dump: `monarch-kg.neo4j.dump` (using `neo4j:4.4`) - for existing infrastructure
- v5 dump: `monarch-kg.neo4j.v5.dump` (using `neo4j:5`) - for newer deployments

## Test plan
- [x] Tested v5 import and dump locally - completed successfully
- [ ] Verify Jenkins build produces both dump files

🤖 Generated with [Claude Code](https://claude.com/claude-code)