### PR TITLE
Remove maxo-annotation and dismech from KG sources

### DIFF
--- a/src/monarch_ingest/ingests.yaml
+++ b/src/monarch_ingest/ingests.yaml
@@ -72,9 +72,6 @@ hpoa:
     - 'https://github.com/monarch-initiative/monarch-phenotype-profile-ingest/releases/latest/download/hpoa_disease_to_phenotype_edges.tsv'
     - 'https://github.com/monarch-initiative/monarch-phenotype-profile-ingest/releases/latest/download/hpoa_gene_to_disease_edges.tsv'
     - 'https://github.com/monarch-initiative/monarch-phenotype-profile-ingest/releases/latest/download/hpoa_gene_to_phenotype_edges.tsv'
-maxo_annotation:
-  url: 
-    - 'https://github.com/monarch-initiative/maxo-annotation-ingest/releases/latest/download/maxo_annotation_edges.tsv'
 ncbi_gene:
   url:
     - 'https://github.com/monarch-initiative/ncbi-gene/releases/latest/download/ncbi_gene_9615_nodes.tsv'
@@ -132,6 +129,3 @@ cureid:
   url:
     - 'https://github.com/monarch-initiative/cureid-ingest/releases/latest/download/cureid_nodes.tsv'
     - 'https://github.com/monarch-initiative/cureid-ingest/releases/latest/download/cureid_edges.tsv'
-dismech:
-  url:
-    - 'https://github.com/monarch-initiative/dismech/releases/latest/download/dismech_edges.jsonl'

--- a/src/monarch_ingest/qc_expect.yaml
+++ b/src/monarch_ingest/qc_expect.yaml
@@ -100,6 +100,4 @@ edges:
       min: 7000
     cureid_edges:
       min: 200
-    dismech_edges:
-      min: 10000
 


### PR DESCRIPTION
## Summary
- Removed `maxo_annotation` ingest from `ingests.yaml`
- Removed `dismech` ingest from `ingests.yaml`
- Removed `dismech_edges` QC expectation from `qc_expect.yaml`

## Test plan
- [ ] Verify KG build completes without maxo-annotation and dismech sources