### PR TITLE
Switch Jenkinsfiles from poetry to uv

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
         HOME = "${env.WORKSPACE}"
         RELEASE = sh(script: "echo `date +%Y-%m-%d`", returnStdout: true).trim()
         BUILD_TIMESTAMP = sh(script: "echo `date +%s`", returnStdout: true).trim()
-        PATH = "/opt/poetry/bin:${env.PATH}"
+        PATH = "${env.WORKSPACE}/.local/bin:${env.PATH}"
         AWS_ACCESS_KEY_ID = credentials('AWS_ACCESS_KEY_ID')        
         AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
         GH_RELEASE_TOKEN = credentials('GH_RELEASE_TOKEN')
@@ -14,18 +14,19 @@ pipeline {
             steps {
                 sh '''
                     echo "Current directory: \\$(pwd)"
-                    # export PATH=$PATH:$HOME/.local/bin
                     echo "Path: $PATH"
-                    
-                    # echo $SHELL
+
                     python3 --version
                     pip --version
-                    poetry --version
-                  
 
-                    # poetry config experimental.new-installer false
-                    poetry install --with dev
-                    poetry run which ingest
+                    # Install uv if not already present on the agent
+                    if ! command -v uv >/dev/null 2>&1; then
+                        curl -LsSf https://astral.sh/uv/install.sh | sh
+                    fi
+                    uv --version
+
+                    make install-full
+                    uv run which ingest
 
                     # temporarily disabling, there isn't a .boto file
                     # create & edit ~/.boto to include AWS credentials
@@ -36,12 +37,12 @@ pipeline {
         }
         stage('download') {
             steps {
-                sh 'poetry run ingest download --all --write-metadata'
+                sh 'uv run ingest download --all --write-metadata'
             }
         }
         stage('transform') {
             steps {
-                sh 'poetry run ingest transform --all --log --write-metadata'
+                sh 'uv run ingest transform --all --log --write-metadata'
                 sh '''
                    sed -i.bak 's@\r@@g' output/transform_output/*.tsv
                    rm output/transform_output/*.bak
@@ -50,44 +51,44 @@ pipeline {
         }
         stage('merge') {
             steps {
-                sh 'poetry run ingest merge'
+                sh 'uv run ingest merge'
             }
         }
         stage('denormalize') {
             steps {
-                sh 'poetry run ingest closure'
+                sh 'uv run ingest closure'
             }
         }
         stage('report') {
             steps {
-                sh 'poetry run ingest report'
+                sh 'uv run ingest report'
             }
         }
         stage('jsonl-conversion'){
             steps {
-                sh 'poetry run ingest jsonl'
+                sh 'uv run ingest jsonl'
             }
         }
         stage('neo4j-csv') {
             steps {
-                sh 'poetry run ingest neo4j-csv'
+                sh 'uv run ingest neo4j-csv'
             }
         }
         stage('parallel-processing') {
             parallel {
                 stage('kgx-graph-summary') {
                     steps {
-                        sh 'poetry run kgx graph-summary -i duckdb --node-facet-properties provided_by --edge-facet-properties provided_by output/monarch-kg.duckdb -o output/merged_graph_stats.yaml'                        
+                        sh 'uv run kgx graph-summary -i duckdb --node-facet-properties provided_by --edge-facet-properties provided_by output/monarch-kg.duckdb -o output/merged_graph_stats.yaml'                        
                     }
                 }
                 stage('solr') {
                     steps {
-                        sh 'poetry run ingest solr'
+                        sh 'uv run ingest solr'
                     }
                 }
                 stage('kgx-transforms'){
                     steps {
-                        sh 'poetry run kgx transform -i duckdb -f nt -d gz -o output/monarch-kg.nt.gz output/monarch-kg.duckdb'
+                        sh 'uv run kgx transform -i duckdb -f nt -d gz -o output/monarch-kg.nt.gz output/monarch-kg.duckdb'
                     }
                 }
                 stage('neo4j-dump') {
@@ -97,12 +98,12 @@ pipeline {
                 }
                 stage('sqlite') {
                     steps {
-                        sh 'poetry run ingest sqlite'
+                        sh 'uv run ingest sqlite'
                     }
                 }
                 stage('make exports') {
                     steps {
-                        sh 'poetry run ingest export'
+                        sh 'uv run ingest export'
                     }
                 }
             }
@@ -110,17 +111,17 @@ pipeline {
 
         stage('upload files') {
             steps {
-                sh 'poetry run ingest release --kghub'
+                sh 'uv run ingest release --kghub'
             }
         }
         stage('create github release') {
             steps {
-                sh 'poetry run python scripts/create_github_release.py --kg-version ${RELEASE}'
+                sh 'uv run python scripts/create_github_release.py --kg-version ${RELEASE}'
             }
         }
         // stage('update dev deployment') {
         //     steps {
-        //         sh 'poetry run python scripts/update-dev-solr.py'
+        //         sh 'uv run python scripts/update-dev-solr.py'
         //     }
         // }
         stage('index') {            

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
         HOME = "${env.WORKSPACE}"
         RELEASE = sh(script: "echo `date +%Y-%m-%d`", returnStdout: true).trim()
         BUILD_TIMESTAMP = sh(script: "echo `date +%s`", returnStdout: true).trim()
-        PATH = "${env.WORKSPACE}/.local/bin:${env.PATH}"
+        PATH = "/opt/uv:${env.PATH}"
         AWS_ACCESS_KEY_ID = credentials('AWS_ACCESS_KEY_ID')        
         AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
         GH_RELEASE_TOKEN = credentials('GH_RELEASE_TOKEN')
@@ -18,11 +18,6 @@ pipeline {
 
                     python3 --version
                     pip --version
-
-                    # Install uv if not already present on the agent
-                    if ! command -v uv >/dev/null 2>&1; then
-                        curl -LsSf https://astral.sh/uv/install.sh | sh
-                    fi
                     uv --version
 
                     make install-full

--- a/Jenkinsfile-redo-solr
+++ b/Jenkinsfile-redo-solr
@@ -2,7 +2,7 @@ pipeline {
     agent { label 'monarch-agent-large' }
     environment {
         HOME = "${env.WORKSPACE}"
-        PATH = "/opt/poetry/bin:${env.PATH}"
+        PATH = "${env.WORKSPACE}/.local/bin:${env.PATH}"
         AWS_ACCESS_KEY_ID = credentials('AWS_ACCESS_KEY_ID')        
         AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
     }
@@ -76,19 +76,19 @@ pipeline {
             steps {
                 sh '''
                     echo "Current directory: $(pwd)"
-                    # export PATH=$PATH:$HOME/.local/bin
                     echo "Path: $PATH"
-                    
-                    # echo $SHELL
+
                     python3 --version
                     pip --version
-                    poetry --version
-                  
 
-                    # poetry config experimental.new-installer false
-                    poetry install --with dev
-                    poetry run which ingest
+                    # Install uv if not already present on the agent
+                    if ! command -v uv >/dev/null 2>&1; then
+                        curl -LsSf https://astral.sh/uv/install.sh | sh
+                    fi
+                    uv --version
 
+                    make install-full
+                    uv run which ingest
                 '''
             }
         }
@@ -111,7 +111,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'poetry run kgx graph-summary -i tsv -c "tar.gz" --node-facet-properties provided_by --edge-facet-properties provided_by output/monarch-kg.tar.gz -o output/merged_graph_stats.yaml'
+                sh 'uv run kgx graph-summary -i tsv -c "tar.gz" --node-facet-properties provided_by --edge-facet-properties provided_by output/monarch-kg.tar.gz -o output/merged_graph_stats.yaml'
             }
         }
         stage('denormalize') {
@@ -121,7 +121,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'poetry run ingest closure'
+                sh 'uv run ingest closure'
             }
         }
         stage('solr') {
@@ -131,7 +131,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'poetry run ingest solr'
+                sh 'uv run ingest solr'
             }
         }
         stage('sqlite') {
@@ -141,7 +141,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'poetry run ingest sqlite'
+                sh 'uv run ingest sqlite'
             }
         }
         stage('make tsv exports') {
@@ -151,7 +151,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'poetry run ingest export'
+                sh 'uv run ingest export'
             }
         }
         stage("jsonl") {
@@ -161,7 +161,7 @@ pipeline {
                }
             }
            steps {
-               sh 'poetry run ingest jsonl'
+               sh 'uv run ingest jsonl'
            }
         }
         stage('kgx-transforms'){
@@ -202,7 +202,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'poetry run python scripts/update-dev-solr.py'
+                sh 'uv run python scripts/update-dev-solr.py'
             }
         }
     }

--- a/Jenkinsfile-redo-solr
+++ b/Jenkinsfile-redo-solr
@@ -2,7 +2,7 @@ pipeline {
     agent { label 'monarch-agent-large' }
     environment {
         HOME = "${env.WORKSPACE}"
-        PATH = "${env.WORKSPACE}/.local/bin:${env.PATH}"
+        PATH = "/opt/uv:${env.PATH}"
         AWS_ACCESS_KEY_ID = credentials('AWS_ACCESS_KEY_ID')        
         AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
     }
@@ -80,11 +80,6 @@ pipeline {
 
                     python3 --version
                     pip --version
-
-                    # Install uv if not already present on the agent
-                    if ! command -v uv >/dev/null 2>&1; then
-                        curl -LsSf https://astral.sh/uv/install.sh | sh
-                    fi
                     uv --version
 
                     make install-full


### PR DESCRIPTION
## Summary
- The Makefile and GitHub workflow moved to uv in #677 (`uvification`), but the Jenkinsfiles were missed. The current Jenkins build fails at `poetry install --with dev` with `Group(s) not found: dev (via --with)` because `dev` is now declared under `[project.optional-dependencies]` rather than a poetry dep group.
- Updates `PATH` from `/opt/poetry/bin` to `/opt/uv`, where the Packer-built agent image installs uv (`monarch-agent.pkr.hcl` runs the installer with `UV_INSTALL_DIR=/opt/uv`), and calls `make install-full` in the `setup` stage to mirror what CI runs.
- Replaces every `poetry run …` with `uv run …` in both `Jenkinsfile` and `Jenkinsfile-redo-solr`.

## Test plan
- [ ] Trigger the main Jenkins pipeline on this branch and confirm the `setup` stage finds `uv --version` on `PATH` and `uv run which ingest` resolves.
- [ ] Confirm subsequent stages (`download`, `transform`, `merge`, …) run under `uv run` without ImportError.
- [ ] Sanity-check `Jenkinsfile-redo-solr` by triggering it (with most flags off) and confirming `setup` succeeds.