### PR TITLE
Scrub remaining poetry references from scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,26 +8,23 @@ The output of the Monarch Ingest process is the **Monarch KG**, available at [da
 
 ## Installation
 
-monarch-ingest is a Python 3.8+ package, installable via [Poetry](https://python-poetry.org).
+monarch-ingest is a Python 3.10+ package, managed with [uv](https://docs.astral.sh/uv/).
 
-1. Install Poetry:
+1. Install uv:
 ```bash
-curl -sSL https://install.python-poetry.org | python3 -
-
-# Optional: Have poetry create its venvs in your project directories
-poetry config virtualenvs.in-project true
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 2. Clone and install:
 ```bash
 git clone git@github.com:monarch-initiative/monarch-ingest
 cd monarch-ingest
-poetry install
+uv sync
 ```
 
-3. (Optional) Activate the virtual environment:
+3. Run commands with `uv run` (or activate the venv with `source .venv/bin/activate`):
 ```bash
-poetry shell
+uv run ingest --help
 ```
 
 ## Quick Start

--- a/build_mokg.sh
+++ b/build_mokg.sh
@@ -1,11 +1,11 @@
 rm output/transform_output/* -rf
 rm data/* -rf
-poetry run ingest download --ingest_file src/monarch_ingest/ingest_configs/mokg_downloads.txt
+uv run ingest download --ingest_file src/monarch_ingest/ingest_configs/mokg_downloads.txt
 bash scripts/after_download.sh
-poetry run ingest transform --phenio
-poetry run ingest transform --ingest_file src/monarch_ingest/ingest_configs/mokg_transforms.txt
-poetry run ingest merge --kg-name mokg
+uv run ingest transform --phenio
+uv run ingest transform --ingest_file src/monarch_ingest/ingest_configs/mokg_transforms.txt
+uv run ingest merge --kg-name mokg
 
 #This is a command to convert the KGX output found in output/mokg.tar.gz into RDF output.
 #This is taken from https://github.com/monarch-initiative/monarch-ingest/blob/3d2b0b3693a021d7660214bcd81abc4409f8efe2/scripts/kgx_transforms.sh#L12
-#poetry run kgx transform -i tsv -c tar.gz -f nt -d gz -o output/monarch-kg.nt.gz output/monarch-kg.tar.gz
+#uv run kgx transform -i tsv -c tar.gz -f nt -d gz -o output/monarch-kg.nt.gz output/monarch-kg.tar.gz

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,35 +9,32 @@ The latest version of this can be found at [data.monarchinitiative.org](https://
 
 See also the folder [monarch-kg-dev/latest](https://data.monarchinitiative.org/monarch-kg-dev/latest/)
 
-Monarch Ingest is built using [Poetry](https://python-poetry.org), which will create its own virtual environment. 
+Monarch Ingest is managed with [uv](https://docs.astral.sh/uv/), which creates and manages its own virtual environment.
 
 ## Installation
 
-monarch-ingest is a Python 3.8+ package, installable via [Poetry](https://python-poetry.org).  
+monarch-ingest is a Python 3.10+ package, managed with [uv](https://docs.astral.sh/uv/).
 
-1. <a href="https://python-poetry.org/docs/" target="_blank">Install Poetry</a>, if you don't already have it:  
+1. <a href="https://docs.astral.sh/uv/getting-started/installation/" target="_blank">Install uv</a>, if you don't already have it:
 ```bash
-curl -sSL https://install.python-poetry.org | python3 -
-
-# Optional: Have poetry create its venvs in your project directories
-poetry config virtualenvs.in-project true
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-1. Clone the repo and build the code:
+1. Clone the repo:
 ```bash
-git clone git@github.com/monarch-initiative/monarch-ingest
+git clone git@github.com:monarch-initiative/monarch-ingest
 ```
 
 1. Install monarch-ingest:
 ```bash
 cd monarch-ingest
-poetry install
+uv sync
 ```
 
 1. (Optional) Activate the virtual environment:
 ```bash
-# This step removes the need to prefix all commands with `poetry run`
-poetry shell
+# This step removes the need to prefix all commands with `uv run`
+source .venv/bin/activate
 ```
 
 ## Usage

--- a/scripts/load_solr.sh
+++ b/scripts/load_solr.sh
@@ -18,7 +18,7 @@ echo "Download the schema files using pystow"
 python -c "from monarch_ingest.cli_utils import ensure_model_files; ensure_model_files()"
 
 echo "Starting the server"
-poetry run lsolr start-server --memory 8g --heap-size 6g --ram-buffer-mb 2048
+uv run lsolr start-server --memory 8g --heap-size 6g --ram-buffer-mb 2048
 echo "Waiting for Solr to be ready..."
 for i in {1..30}; do
   if curl -s http://localhost:8983/solr/admin/info/system >/dev/null 2>&1; then
@@ -35,7 +35,7 @@ if ! curl -s http://localhost:8983/solr/admin/info/system >/dev/null 2>&1; then
 fi
 
 echo "Adding cores"
-poetry run lsolr add-cores entity association sssom infores
+uv run lsolr add-cores entity association sssom infores
 sleep 30
 
 # todo: ideally, this will live in linkml-solr
@@ -44,11 +44,11 @@ scripts/add_fieldtypes.sh
 sleep 5
 
 echo "Adding entity schema"
-poetry run lsolr create-schema -C entity -s model.yaml -t Entity
+uv run lsolr create-schema -C entity -s model.yaml -t Entity
 sleep 5
 
 echo "Adding association schema"
-poetry run lsolr create-schema -C association -s model.yaml -t Association
+uv run lsolr create-schema -C association -s model.yaml -t Association
 sleep 5
 
 # turn off transaction logging for the big indexes
@@ -65,11 +65,11 @@ for core_name in "${core_names[@]}"; do
 done
 
 echo "Adding sssom schema"
-poetry run lsolr create-schema -C sssom -s model.yaml -t Mapping
+uv run lsolr create-schema -C sssom -s model.yaml -t Mapping
 sleep 5
 
 echo "Adding infores schema"
-poetry run lsolr create-schema -C infores -s data/infores/information_resource_registry.yaml -t InformationResource
+uv run lsolr create-schema -C infores -s data/infores/information_resource_registry.yaml -t InformationResource
 
 # todo: this also should live in linkml-solr, and copy-fields should be based on the schema
 echo "Add dynamic fields and copy fields declarations"
@@ -88,13 +88,13 @@ curl -X POST -H 'Content-Type: application/json' \
   --data-binary @data/infores/infores_catalog.jsonl
 
 
-poetry run lsolr bulkload-db -C sssom -s model.yaml output/monarch-kg.duckdb mappings
+uv run lsolr bulkload-db -C sssom -s model.yaml output/monarch-kg.duckdb mappings
 
 echo "Loading entities"
 
-poetry run lsolr bulkload-db -C entity -s model.yaml output/monarch-kg.duckdb denormalized_nodes
+uv run lsolr bulkload-db -C entity -s model.yaml output/monarch-kg.duckdb denormalized_nodes
 
-poetry run lsolr bulkload-db -C association -s model.yaml --processor frequency_update_processor output/monarch-kg.duckdb denormalized_edges
+uv run lsolr bulkload-db -C association -s model.yaml --processor frequency_update_processor output/monarch-kg.duckdb denormalized_edges
 # curl "http://localhost:8983/solr/association/select?q=*:*"
 
 


### PR DESCRIPTION
## Summary
Followup to #677 (`uvification`), which moved the Makefile and CI to uv but left a handful of references behind. Searched the tracked tree for `poetry` and updated the four files that still mentioned it:

- `scripts/load_solr.sh` — 8 `poetry run lsolr` → `uv run lsolr`
- `build_mokg.sh` — 4 `poetry run` → `uv run` (plus the commented-out kgx example)
- `README.md` — install section rewritten for uv (`uv sync`, `uv run`, Python 3.10+)
- `docs/index.md` — same rewrite, plus fixed the `git@github.com/` typo to `git@github.com:`

After this PR, `git ls-files | xargs grep -n poetry` returns nothing.

Companion to #679, which handles the Jenkinsfiles.

## Test plan
- [ ] `bash scripts/load_solr.sh` runs locally end-to-end against a fresh checkout where uv is on `PATH`.
- [ ] `bash build_mokg.sh` runs the download/transform/merge pipeline without command-not-found errors.
- [ ] Skim the rendered docs (`mkdocs serve`) to confirm the install section reads sensibly.