### PR TITLE
Aggregate per-ingest release metadata into a build receipt

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,12 +32,13 @@ pipeline {
         }
         stage('download') {
             steps {
-                sh 'uv run ingest download --all --write-metadata'
+                sh 'uv run ingest download --all'
+                sh 'uv run ingest download-release-metadata'
             }
         }
         stage('transform') {
             steps {
-                sh 'uv run ingest transform --all --log --write-metadata'
+                sh 'uv run ingest transform --all --log'
                 sh '''
                    sed -i.bak 's@\r@@g' output/transform_output/*.tsv
                    rm output/transform_output/*.bak
@@ -104,6 +105,11 @@ pipeline {
             }
         }
 
+        stage('build receipt') {
+            steps {
+                sh 'uv run ingest build-receipt --kg-version ${RELEASE}'
+            }
+        }
         stage('upload files') {
             steps {
                 sh 'uv run ingest release --kghub'

--- a/build_mokg.sh
+++ b/build_mokg.sh
@@ -1,10 +1,12 @@
 rm output/transform_output/* -rf
 rm data/* -rf
 uv run ingest download --ingest_file src/monarch_ingest/ingest_configs/mokg_downloads.txt
+uv run ingest download-release-metadata
 bash scripts/after_download.sh
 uv run ingest transform --phenio
 uv run ingest transform --ingest_file src/monarch_ingest/ingest_configs/mokg_transforms.txt
 uv run ingest merge --kg-name mokg
+uv run ingest build-receipt --kg-name mokg
 
 #This is a command to convert the KGX output found in output/mokg.tar.gz into RDF output.
 #This is taken from https://github.com/monarch-initiative/monarch-ingest/blob/3d2b0b3693a021d7660214bcd81abc4409f8efe2/scripts/kgx_transforms.sh#L12

--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -35,8 +35,9 @@ from monarch_ingest.utils.ingest_utils import (
     ingest_output_exists,
     file_exists,
     get_ingests,
-    get_release_metadata_repos,
+    get_release_metadata_sources,
     ingest_urls,
+    is_metadata_only,
 )
 from monarch_ingest.utils.log_utils import get_logger
 from monarch_ingest.utils.export_utils import export
@@ -96,6 +97,11 @@ def transform_one(
     if ingest not in ingests:
         # if log: logger.removeHandler(fh)
         raise ValueError(f"{ingest} is not a valid ingest - see ingests.yaml for a list of options")
+
+    if is_metadata_only(ingests[ingest]):
+        raise ValueError(
+            f"{ingest} is a metadata-only entry (contributes to the build receipt but is not a transform)"
+        )
 
     logger.info(f"Running ingest: {ingest}")
     # If urls can be resolved (url-style or kozahub repo-style), just download and copy.
@@ -329,7 +335,7 @@ def transform_all(
     except Exception as e:
         logger.error(f"Error running Phenio ingest: {e}")
 
-    ingests = get_ingests()
+    ingests = {k: v for k, v in get_ingests().items() if not is_metadata_only(v)}
 
     # Determine optimal number of workers based on CPU cores
     # Use min of (cpu_count, number_of_ingests, 8) to avoid overwhelming the system
@@ -372,31 +378,26 @@ def transform_all(
     # if log: logger.removeHandler(fh)
 
 
-RELEASE_METADATA_URL = (
-    "https://github.com/monarch-initiative/{repo}/releases/latest/download/release-metadata.yaml"
-)
-
-
 def download_release_metadata(
-    repos: Optional[list] = None,
+    sources: Optional[list] = None,
     output_dir: str = "data/release-metadata",
 ):
-    """Fetch each ingest repo's `release-metadata.yaml` GitHub release asset.
+    """Fetch each kozahub repo's `release-metadata.yaml`.
 
-    Missing or unreachable files log a warning and are skipped — the build receipt
-    will be incomplete rather than fail. Returns the list of repos for which a
-    metadata file was successfully written.
+    `sources` is a list of `(repo, url)` tuples; defaults to whatever
+    `ingests.yaml` declares (`metadata_url:` override, otherwise the standard
+    GitHub-releases asset URL). Missing or unreachable files log a warning
+    and are skipped. Returns the list of repos for which a file was written.
     """
     logger = get_logger()
-    if repos is None:
-        repos = get_release_metadata_repos()
+    if sources is None:
+        sources = get_release_metadata_sources()
 
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 
     written = []
-    for repo in repos:
-        url = RELEASE_METADATA_URL.format(repo=repo)
+    for repo, url in sources:
         try:
             resp = requests.get(url, allow_redirects=True, timeout=30)
         except requests.RequestException as e:
@@ -414,7 +415,7 @@ def download_release_metadata(
         written.append(repo)
         logger.info(f"Fetched release-metadata.yaml for {repo}")
 
-    logger.info(f"Wrote release-metadata for {len(written)}/{len(repos)} repos to {output_dir}")
+    logger.info(f"Wrote release-metadata for {len(written)}/{len(sources)} repos to {output_dir}")
     return written
 
 

--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -1046,9 +1046,9 @@ def do_release(dir: str = OUTPUT_DIR, kghub: bool = False):
     # ensure that files that should be compressed are
 
     with open(f"{dir}/metadata.yaml", "r") as f:
-        versions = yaml.load(f, Loader=yaml.FullLoader)
+        receipt = yaml.load(f, Loader=yaml.FullLoader)
 
-    release_ver = versions["kg-version"]
+    release_ver = receipt["version"]
 
     logger = get_logger()
     logger.info(f"Creating dated release: {release_ver}...")

--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -31,7 +31,13 @@ from koza.runner import KozaRunner
 from koza.model.formats import OutputFormat
 from linkml_runtime.utils.formatutils import camelcase
 
-from monarch_ingest.utils.ingest_utils import ingest_output_exists, file_exists, get_ingests
+from monarch_ingest.utils.ingest_utils import (
+    ingest_output_exists,
+    file_exists,
+    get_ingests,
+    get_release_metadata_repos,
+    ingest_urls,
+)
 from monarch_ingest.utils.log_utils import get_logger
 from monarch_ingest.utils.export_utils import export
 
@@ -92,13 +98,14 @@ def transform_one(
         raise ValueError(f"{ingest} is not a valid ingest - see ingests.yaml for a list of options")
 
     logger.info(f"Running ingest: {ingest}")
-    # if a url is provided instead of a config, just download the file and copy it to the output dir
-    if "url" in ingests[ingest]:
+    # If urls can be resolved (url-style or kozahub repo-style), just download and copy.
+    urls = ingest_urls(ingests[ingest])
+    if urls:
         logger.info(
             f"{ingest} has been found to be modular, downloading provided urls to {output_dir}/transform_output"
         )
         save_as_map = ingests[ingest].get("save_as", {})
-        for url in ingests[ingest]["url"]:
+        for url in urls:
             filename = url.split("/")[-1]
             filename = save_as_map.get(filename, filename)
             # Creates/checks existance of $OUTPUT_DIR/ and $OUTPUT_DIR/transform_output/
@@ -365,45 +372,56 @@ def transform_all(
     # if log: logger.removeHandler(fh)
 
 
+RELEASE_METADATA_URL = (
+    "https://github.com/monarch-initiative/{repo}/releases/latest/download/release-metadata.yaml"
+)
+
+
+def download_release_metadata(
+    repos: Optional[list] = None,
+    output_dir: str = "data/release-metadata",
+):
+    """Fetch each ingest repo's `release-metadata.yaml` GitHub release asset.
+
+    Missing or unreachable files log a warning and are skipped — the build receipt
+    will be incomplete rather than fail. Returns the list of repos for which a
+    metadata file was successfully written.
+    """
+    logger = get_logger()
+    if repos is None:
+        repos = get_release_metadata_repos()
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    written = []
+    for repo in repos:
+        url = RELEASE_METADATA_URL.format(repo=repo)
+        try:
+            resp = requests.get(url, allow_redirects=True, timeout=30)
+        except requests.RequestException as e:
+            logger.warning(f"release-metadata.yaml fetch failed for {repo}: {e}")
+            continue
+        if resp.status_code == 404:
+            logger.warning(f"release-metadata.yaml not found for {repo} (skipping)")
+            continue
+        if not resp.ok:
+            logger.warning(
+                f"release-metadata.yaml fetch returned {resp.status_code} for {repo} (skipping)"
+            )
+            continue
+        (out / f"{repo}.yaml").write_bytes(resp.content)
+        written.append(repo)
+        logger.info(f"Fetched release-metadata.yaml for {repo}")
+
+    logger.info(f"Wrote release-metadata for {len(written)}/{len(repos)} repos to {output_dir}")
+    return written
+
+
 def get_release_version():
     import datetime
 
     return datetime.datetime.now().strftime("%Y-%m-%d")
-
-
-def get_data_versions(output_dir: str = OUTPUT_DIR):
-    import requests as r
-
-    data = {}
-    data["phenio"] = r.get("https://api.github.com/repos/monarch-initiative/phenio/releases").json()[0]["tag_name"]
-    data["alliance"] = r.get("https://fms.alliancegenome.org/api/releaseversion/current").json()["releaseVersion"]
-    Path(f"{output_dir}").mkdir(parents=True, exist_ok=True)
-    with open(f"{output_dir}/metadata.yaml", "w") as f:
-        f.write("data:\n")
-        for data_source, version in data.items():
-            f.write(f"  {data_source}: {str(version)}\n")
-
-
-def get_pkg_versions(output_dir: str = OUTPUT_DIR, release_version: Optional[str] = None):
-    from importlib.metadata import version
-
-    packages = {}
-    packages["biolink"] = version("biolink-model")
-    packages["koza"] = version("koza")
-    packages["monarch-ingest"] = version("monarch-ingest")
-    kg_version = get_release_version() if release_version is None else release_version
-    with open("data/metadata.yaml", "r") as f:
-        data_versions = yaml.load(f, Loader=yaml.FullLoader)["data"]
-
-    Path(f"{output_dir}").mkdir(parents=True, exist_ok=True)
-    with open(f"{output_dir}/metadata.yaml", "w") as f:
-        f.write(f"kg-version: {str(kg_version)}\n\n")
-        f.write("packages:\n")
-        for k, v in packages.items():
-            f.write(f"  {k}: {str(v)}\n")
-        f.write("\ndata:\n")
-        for k, v in data_versions.items():
-            f.write(f"  {k}: {str(v)}\n")
 
 
 def merge_files(

--- a/src/monarch_ingest/ingests.yaml
+++ b/src/monarch_ingest/ingests.yaml
@@ -1,131 +1,208 @@
-
-## Pass-through modular ingests
+## Entries come in three shapes:
+##
+##   url:    a list of explicit URLs to fetch (pass-through download).
+##   config: path to a koza transform config yaml.
+##   repo:   a kozahub ingest repo whose `release-metadata.yaml` is fetched as
+##           part of the build receipt. URLs are derived as
+##           https://github.com/monarch-initiative/<repo>/releases/latest/download/<file>.
 
 bgee_gene_to_expression:
-  url:
-    - 'https://github.com/monarch-initiative/bgee-ingest/releases/latest/download/bgee_gene_to_expression_edges.tsv'
+  repo: bgee-ingest
+  files:
+    - bgee_gene_to_expression_edges.tsv
+
 string_protein_links:
-  url:
-    - 'https://github.com/monarch-initiative/string-ingest/releases/latest/download/string_protein_links_edges.tsv'
+  repo: string-ingest
+  files:
+    - string_protein_links_edges.tsv
+
 ctd_chemical_to_disease:
-  url:
-    - 'https://github.com/monarch-initiative/ctd-ingest/releases/latest/download/ctd_chemical_to_disease_edges.tsv'
+  repo: ctd-ingest
+  files:
+    - ctd_chemical_to_disease_edges.tsv
+
 dictybase_gene:
-  url:
-    - 'https://github.com/monarch-initiative/dictybase-ingest/releases/latest/download/dictybase_gene_nodes.tsv'
+  repo: dictybase-ingest
+  files:
+    - dictybase_gene_nodes.tsv
+
 dictybase_gene_to_phenotype:
-  url:
-    - 'https://github.com/monarch-initiative/dictybase-ingest/releases/latest/download/dictybase_gene_to_phenotype_edges.tsv'
+  repo: dictybase-ingest
+  files:
+    - dictybase_gene_to_phenotype_edges.tsv
+
 hgnc_gene:
-  url:
-    - 'https://github.com/monarch-initiative/hgnc-ingest/releases/latest/download/hgnc_gene_nodes.tsv'
+  repo: hgnc-ingest
+  files:
+    - hgnc_gene_nodes.tsv
+
 pombase_gene:
-  url:
-    - 'https://github.com/monarch-initiative/pombase-ingest/releases/latest/download/pombase_gene_nodes.tsv'
+  repo: pombase-ingest
+  files:
+    - pombase_gene_nodes.tsv
+
 pombase_gene_to_phenotype:
-  url:
-    - 'https://github.com/monarch-initiative/pombase-ingest/releases/latest/download/pombase_gene_to_phenotype_edges.tsv'
+  repo: pombase-ingest
+  files:
+    - pombase_gene_to_phenotype_edges.tsv
+
 reactome_pathway:
-  url:
-    - 'https://github.com/monarch-initiative/reactome-ingest/releases/latest/download/reactome_pathway_nodes.tsv'
+  repo: reactome-ingest
+  files:
+    - reactome_pathway_nodes.tsv
+
 reactome_gene_to_pathway:
-  url:
-    - 'https://github.com/monarch-initiative/reactome-ingest/releases/latest/download/reactome_gene_to_pathway_edges.tsv'
+  repo: reactome-ingest
+  files:
+    - reactome_gene_to_pathway_edges.tsv
+
 reactome_chemical_to_pathway:
-  url:
-    - 'https://github.com/monarch-initiative/reactome-ingest/releases/latest/download/reactome_chemical_to_pathway_edges.tsv'
+  repo: reactome-ingest
+  files:
+    - reactome_chemical_to_pathway_edges.tsv
+
 alliance_gene:
-  url: 
-    - 'https://github.com/monarch-initiative/alliance-ingest/releases/latest/download/alliance_gene_nodes.tsv'
+  repo: alliance-ingest
+  files:
+    - alliance_gene_nodes.tsv
+
 alliance_genotype:
-  url:
-    - 'https://github.com/monarch-initiative/alliance-ingest/releases/latest/download/alliance_genotype_nodes.tsv'
-    - 'https://github.com/monarch-initiative/alliance-ingest/releases/latest/download/alliance_genotype_edges.tsv'
-    - 'https://github.com/monarch-initiative/alliance-ingest/releases/latest/download/alliance_allele_nodes.tsv'
-    - 'https://github.com/monarch-initiative/alliance-ingest/releases/latest/download/alliance_allele_edges.tsv'
+  repo: alliance-ingest
+  files:
+    - alliance_genotype_nodes.tsv
+    - alliance_genotype_edges.tsv
+    - alliance_allele_nodes.tsv
+    - alliance_allele_edges.tsv
+
 alliance_gene_to_expression:
-  url:
-    - 'https://github.com/monarch-initiative/alliance-ingest/releases/latest/download/alliance_gene_to_expression_edges.tsv'
+  repo: alliance-ingest
+  files:
+    - alliance_gene_to_expression_edges.tsv
+
 alliance_phenotype:
-  url:
-    - 'https://github.com/monarch-initiative/alliance-ingest/releases/latest/download/alliance_phenotype_edges.tsv'
+  repo: alliance-ingest
+  files:
+    - alliance_phenotype_edges.tsv
+
 alliance_disease_association:
-  url:
-    - 'https://github.com/monarch-initiative/alliance-disease-association-ingest/releases/latest/download/alliance_disease_edges.tsv'
+  repo: alliance-ingest
+  files:
+    - alliance_disease_edges.tsv
+
 biogrid:
-  url:
-    - 'https://github.com/monarch-initiative/biogrid-ingest/releases/latest/download/biogrid_gene_to_gene_edges.tsv'
+  repo: biogrid-ingest
+  files:
+    - biogrid_gene_to_gene_edges.tsv
+
 clingen_gene_disease_edges:
-  url:
-    - 'https://github.com/monarch-initiative/clingen-ingest/releases/latest/download/clingen_gene_disease_edges.tsv'
+  repo: clingen-ingest
+  files:
+    - clingen_gene_disease_edges.tsv
+
 clingen_variant:
-  url:
-    - 'https://github.com/monarch-initiative/clingen-ingest/releases/latest/download/clingen_variant_nodes.tsv'
-    - 'https://github.com/monarch-initiative/clingen-ingest/releases/latest/download/clingen_variant_edges.tsv'
+  repo: clingen-ingest
+  files:
+    - clingen_variant_nodes.tsv
+    - clingen_variant_edges.tsv
+
 clinvar_variant:
-  url:
-    - 'https://github.com/monarch-initiative/clinvar-ingest/releases/latest/download/clinvar_variant_nodes.tsv'
-    - 'https://github.com/monarch-initiative/clinvar-ingest/releases/latest/download/clinvar_variant_edges.tsv'
+  repo: clinvar-ingest
+  files:
+    - clinvar_variant_nodes.tsv
+    - clinvar_variant_edges.tsv
+
 hpoa:
-  url:
-    - 'https://github.com/monarch-initiative/monarch-phenotype-profile-ingest/releases/latest/download/hpoa_disease_mode_of_inheritance_edges.tsv'
-    - 'https://github.com/monarch-initiative/monarch-phenotype-profile-ingest/releases/latest/download/hpoa_disease_to_phenotype_edges.tsv'
-    - 'https://github.com/monarch-initiative/monarch-phenotype-profile-ingest/releases/latest/download/hpoa_gene_to_disease_edges.tsv'
-    - 'https://github.com/monarch-initiative/monarch-phenotype-profile-ingest/releases/latest/download/hpoa_gene_to_phenotype_edges.tsv'
+  repo: monarch-phenotype-profile-ingest
+  files:
+    - hpoa_disease_mode_of_inheritance_edges.tsv
+    - hpoa_disease_to_phenotype_edges.tsv
+    - hpoa_gene_to_disease_edges.tsv
+    - hpoa_gene_to_phenotype_edges.tsv
+
 ncbi_gene:
-  url:
-    - 'https://github.com/monarch-initiative/ncbi-gene/releases/latest/download/ncbi_gene_9615_nodes.tsv'
-    - 'https://github.com/monarch-initiative/ncbi-gene/releases/latest/download/ncbi_gene_9913_nodes.tsv'
-    - 'https://github.com/monarch-initiative/ncbi-gene/releases/latest/download/ncbi_gene_9823_nodes.tsv'
-    - 'https://github.com/monarch-initiative/ncbi-gene/releases/latest/download/ncbi_gene_9031_nodes.tsv'
-    - 'https://github.com/monarch-initiative/ncbi-gene/releases/latest/download/ncbi_gene_227321_nodes.tsv'
+  repo: ncbi-gene
+  files:
+    - ncbi_gene_9615_nodes.tsv
+    - ncbi_gene_9913_nodes.tsv
+    - ncbi_gene_9823_nodes.tsv
+    - ncbi_gene_9031_nodes.tsv
+    - ncbi_gene_227321_nodes.tsv
+
 upheno_phenotype_to_phenotype:
-  url:
-    - 'https://github.com/monarch-initiative/upheno-cross-species-ingest/releases/download/latest/upheno_phenotype_to_phenotype_edges.tsv'
+  repo: upheno-cross-species-ingest
+  files:
+    - upheno_phenotype_to_phenotype_edges.tsv
+
 upheno_filtered_phenotype_to_phenotype:
-  url:
-    - 'https://github.com/monarch-initiative/upheno-cross-species-ingest/releases/download/latest/upheno_phenotype_to_phenotype_filtered_edges.tsv'
+  repo: upheno-cross-species-ingest
+  files:
+    - upheno_phenotype_to_phenotype_filtered_edges.tsv
 
 pantherdb_ortholog:
-  url:
-    - https://github.com/monarch-initiative/pantherdb-orthologs-ingest/releases/latest/download/panther_genome_orthologs_edges.tsv
+  repo: pantherdb-orthologs-ingest
+  files:
+    - panther_genome_orthologs_edges.tsv
+
 zfin_gene_to_phenotype:
-  url:
-    - 'https://github.com/monarch-initiative/zfin-ingest/releases/latest/download/zfin_gene_to_phenotype_edges.tsv'
+  repo: zfin-ingest
+  files:
+    - zfin_gene_to_phenotype_edges.tsv
+
 zfin_genotype_to_phenotype:
-  url:
-    - 'https://github.com/monarch-initiative/zfin-ingest/releases/latest/download/zfin_genotype_to_phenotype_edges.tsv'
+  repo: zfin-ingest
+  files:
+    - zfin_genotype_to_phenotype_edges.tsv
+
 go_annotation:
-  url:
-    - 'https://github.com/monarch-initiative/go-ingest/releases/latest/download/go_annotation_edges.tsv'
+  repo: go-ingest
+  files:
+    - go_annotation_edges.tsv
+
 zfin_orthology:
-  url:
-    - 'https://github.com/monarch-initiative/zfin-ingest/releases/latest/download/zfin_orthology_edges.tsv'
+  repo: zfin-ingest
+  files:
+    - zfin_orthology_edges.tsv
+
 omim_gene_to_disease:
-  url:
-    - 'https://github.com/monarch-initiative/omim-ingest/releases/latest/download/omim_gene_to_disease_edges.tsv'
+  repo: omim-ingest
+  files:
+    - omim_gene_to_disease_edges.tsv
+
 phenopacket_ingest:
-  url:
-    - 'https://github.com/monarch-initiative/phenopacket-ingest/releases/latest/download/phenopacket_ingest_nodes.tsv'
-    - 'https://github.com/monarch-initiative/phenopacket-ingest/releases/latest/download/phenopacket_ingest_edges.tsv'
+  repo: phenopacket-ingest
+  files:
+    - phenopacket_ingest_nodes.tsv
+    - phenopacket_ingest_edges.tsv
+
 xenbase_gene_to_phenotype:
-  url:
-    - 'https://github.com/monarch-initiative/xenbase-ingest/releases/latest/download/xenbase_gene_to_phenotype_edges.tsv'
+  repo: xenbase-ingest
+  files:
+    - xenbase_gene_to_phenotype_edges.tsv
+
 xenbase_orthologs:
-  url:
-    - 'https://github.com/monarch-initiative/xenbase-ingest/releases/latest/download/xenbase_orthologs_edges.tsv'
+  repo: xenbase-ingest
+  files:
+    - xenbase_orthologs_edges.tsv
+
 xenbase_non_entrez_orthologs:
-  url:
-    - 'https://github.com/monarch-initiative/xenbase-ingest/releases/latest/download/xenbase_non_entrez_orthologs_edges.tsv'
+  repo: xenbase-ingest
+  files:
+    - xenbase_non_entrez_orthologs_edges.tsv
+
 mmrrc:
-  url:
-    - 'https://github.com/monarch-initiative/mmrrc-ingest/releases/latest/download/mmrrc_allele_to_genotype_edges.tsv'
-    - 'https://github.com/monarch-initiative/mmrrc-ingest/releases/latest/download/mmrrc_genotype_nodes.tsv'
-    - 'https://github.com/monarch-initiative/mmrrc-ingest/releases/latest/download/mmrrc_genotype_to_phenotype_edges.tsv'
+  repo: mmrrc-ingest
+  files:
+    - mmrrc_allele_to_genotype_edges.tsv
+    - mmrrc_genotype_nodes.tsv
+    - mmrrc_genotype_to_phenotype_edges.tsv
+
 medic_drug_to_disease:
-  url:
-    - 'https://github.com/monarch-initiative/medic-ingest/releases/latest/download/medic_indication_edges.tsv'
+  repo: medic-ingest
+  files:
+    - medic_indication_edges.tsv
+
 cureid:
-  url:
-    - 'https://github.com/monarch-initiative/cureid-ingest/releases/latest/download/cureid_nodes.tsv'
-    - 'https://github.com/monarch-initiative/cureid-ingest/releases/latest/download/cureid_edges.tsv'
+  repo: cureid-ingest
+  files:
+    - cureid_nodes.tsv
+    - cureid_edges.tsv

--- a/src/monarch_ingest/ingests.yaml
+++ b/src/monarch_ingest/ingests.yaml
@@ -5,6 +5,10 @@
 ##   repo:   a kozahub ingest repo whose `release-metadata.yaml` is fetched as
 ##           part of the build receipt. URLs are derived as
 ##           https://github.com/monarch-initiative/<repo>/releases/latest/download/<file>.
+##           Optional `metadata_url:` overrides the default release-metadata.yaml
+##           location for repos that don't publish via GitHub releases.
+##           Omit `files:` for a metadata-only entry — contributes to the build
+##           receipt but isn't a transform target.
 
 bgee_gene_to_expression:
   repo: bgee-ingest
@@ -206,3 +210,10 @@ cureid:
   files:
     - cureid_nodes.tsv
     - cureid_edges.tsv
+
+# kg-phenio is consumed via download.yaml (kg-phenio.tar.gz), not via the
+# kozahub artifact pattern, so this is a metadata-only entry: it contributes
+# its release-metadata.yaml to the build receipt but has no transform.
+kg_phenio:
+  repo: kg-phenio
+  metadata_url: https://kg-hub.berkeleybop.io/kg-phenio/current/release-metadata.yaml

--- a/src/monarch_ingest/main.py
+++ b/src/monarch_ingest/main.py
@@ -32,11 +32,9 @@ def download(
         None, "--ingest_file", help="A yaml file which has a newline seperated list of ingests to perform."
     ),
     all: bool = typer.Option(True, help="Download all ingest datasets"),
-    write_metadata: bool = typer.Option(False, help="Write versions of ingests to metadata.yaml"),
 ):
     """Downloads data defined in download.yaml and runs post-download processing"""
     from kghub_downloader.download_utils import download_from_yaml
-    from monarch_ingest.cli_utils import get_data_versions
 
     if ingest:
         ingests = [ingest]
@@ -64,8 +62,86 @@ def download(
         else:
             logger.info("Post-download processing complete.")
 
-    if write_metadata:
-        get_data_versions(output_dir="data")
+
+@typer_app.command("download-release-metadata")
+def download_release_metadata_cmd(
+    output_dir: str = typer.Option(
+        "data/release-metadata",
+        "--output-dir",
+        "-o",
+        help="Directory to write per-repo release-metadata.yaml files",
+    ),
+):
+    """Fetch `release-metadata.yaml` from each ingest repo's latest GitHub release."""
+    from monarch_ingest.cli_utils import download_release_metadata
+
+    download_release_metadata(output_dir=output_dir)
+
+
+@typer_app.command("build-receipt")
+def build_receipt_cmd(
+    input_dir: str = typer.Option(
+        "data/release-metadata",
+        "--input-dir",
+        "-i",
+        help="Directory of per-ingest release-metadata.yaml files",
+    ),
+    output_dir: str = typer.Option(
+        OUTPUT_DIR, "--output-dir", "-o", help="Directory to write metadata.yaml"
+    ),
+    kg_name: str = typer.Option("monarch-kg", "--kg-name", help="Name of the KG being built"),
+    kg_version: str = typer.Option(
+        None, "--kg-version", help="Version tag (defaults to today's date)"
+    ),
+):
+    """Aggregate per-ingest release-metadata.yaml files into output/metadata.yaml."""
+    from importlib.metadata import version as pkg_version, PackageNotFoundError
+
+    from monarch_ingest.cli_utils import get_release_version
+    from monarch_ingest.release_metadata import (
+        aggregate,
+        collect_kg_artifacts,
+        write_receipt,
+    )
+
+    logger = get_logger()
+
+    packages = {}
+    for pkg in ("biolink-model", "koza", "monarch-ingest"):
+        try:
+            packages[pkg.replace("-model", "")] = pkg_version(pkg)
+        except PackageNotFoundError:
+            pass
+
+    artifacts = collect_kg_artifacts(
+        output_dir,
+        [f"{kg_name}.tar.gz", "merged_graph_stats.yaml", "qc_report.yaml"],
+    )
+
+    receipt = aggregate(
+        input_dir=input_dir,
+        kg_name=kg_name,
+        kg_version=kg_version or get_release_version(),
+        packages=packages,
+        artifacts=artifacts,
+    )
+
+    out_path = Path(output_dir) / "metadata.yaml"
+    write_receipt(receipt, out_path)
+
+    n_sources = len(receipt.get("sources") or [])
+    n_disagreements = len(receipt.get("disagreements") or [])
+    n_drift = len(receipt.get("version_drift") or [])
+    logger.info(
+        f"Wrote build receipt for {kg_name} {receipt['version']} "
+        f"to {out_path} ({n_sources} ingest sources, "
+        f"{n_disagreements} disagreement(s), {n_drift} drift)"
+    )
+
+    for d in receipt.get("disagreements") or []:
+        logger.warning(f"version disagreement on {d['id']}: {d['by_ingest']}")
+    for d in receipt.get("version_drift") or []:
+        logger.warning(f"rolling-source drift on {d['id']}: {d['by_ingest']}")
 
 
 @typer_app.command()
@@ -91,11 +167,10 @@ def transform(
     ),
     log: bool = typer.Option(False, "--log", "-l", help="Write DEBUG level logs to ./logs/ for each ingest"),
     row_limit: int = typer.Option(None, "--row-limit", "-n", help="Number of rows to process"),
-    write_metadata: bool = typer.Option(False, help="Write data/package versions to output_dir/metadata.yaml"),
     # parallel: int = typer.Option(None, "--parallel", "-p", help="Utilize Dask to perform multiple ingests in parallel"),
 ):
     """Run Koza transformation on specified Monarch ingests"""
-    from monarch_ingest.cli_utils import transform_one, transform_phenio, transform_all, get_pkg_versions
+    from monarch_ingest.cli_utils import transform_one, transform_phenio, transform_all
 
     if ingest == None and ingests == None and ingest_file == None and all == False and phenio == False:
         raise ValueError(
@@ -134,8 +209,6 @@ def transform(
             verbose=verbose,
             log=log,
         )
-    if write_metadata:
-        get_pkg_versions(output_dir=output_dir)
 
 
 @typer_app.command()

--- a/src/monarch_ingest/release_metadata.py
+++ b/src/monarch_ingest/release_metadata.py
@@ -1,12 +1,9 @@
 """Aggregate per-ingest `release-metadata.yaml` files into a monarch-kg build receipt.
 
-Each per-ingest file (a `kozahub_metadata_schema:ReleaseMetadata`) is rewritten
-as a nested `Release` (per the recursive shape in kozahub-metadata-schema): the
-top-level `source`/`source_version` becomes `id`/`version`. Leaf upstream
-`SourceVersion` records already use `id`/`version` and slot in unchanged.
-
-Cross-ingest version disagreements (same `infores:` consumed at different
-versions across contributing ingests) are surfaced at the top level of the
+Each per-ingest file is a `kozahub_metadata_schema:Release` and slots in
+verbatim as a nested `Release` under monarch-kg's `sources`. Cross-ingest
+version disagreements (same `infores:` consumed at different versions
+across contributing ingests) are surfaced at the top level of the
 aggregated document.
 """
 
@@ -37,38 +34,6 @@ def load_per_ingest_metadata(input_dir: str | Path) -> list[dict]:
     return [yaml.safe_load(p.read_text()) for p in files]
 
 
-_NESTED_KEY_ORDER = (
-    "id",
-    "version",
-    "transform_version",
-    "biolink_version",
-    "build_version",
-    "generated_at",
-    "sources",
-    "artifacts",
-    "tools",
-)
-
-
-def to_nested_release(per_ingest: dict) -> dict:
-    """Promote a per-ingest `ReleaseMetadata` doc to a nested `Release`.
-
-    Renames `source` → `id` and `source_version` → `version`; everything else
-    (transform_version, biolink_version, build_version, generated_at, sources,
-    artifacts, tools) is already in the right shape.
-    """
-    promoted = dict(per_ingest)
-    promoted["id"] = promoted.pop("source")
-    if "source_version" in promoted:
-        promoted["version"] = promoted.pop("source_version")
-
-    ordered = {k: promoted[k] for k in _NESTED_KEY_ORDER if k in promoted}
-    for k, v in promoted.items():
-        if k not in ordered:
-            ordered[k] = v
-    return ordered
-
-
 # `version_method` values whose "version" is a moving snapshot timestamp
 # (not a stable release identifier). Skew across ingests on these methods is
 # expected — they're flagged as `version_drift` rather than `disagreements`.
@@ -90,7 +55,7 @@ def find_disagreements(per_ingest_docs: list[dict]) -> tuple[list[dict], list[di
     """
     by_source: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
     for doc in per_ingest_docs:
-        ingest = doc.get("source")
+        ingest = doc.get("id")
         for src in doc.get("sources") or []:
             sid = src.get("id")
             if sid:
@@ -131,7 +96,6 @@ def aggregate(
     the contributing builds).
     """
     per_ingest_docs = load_per_ingest_metadata(input_dir)
-    nested_sources = [to_nested_release(d) for d in per_ingest_docs]
     disagreements, drift = find_disagreements(per_ingest_docs)
 
     receipt: dict = {
@@ -143,7 +107,7 @@ def aggregate(
         receipt["packages"] = dict(packages)
     if artifacts:
         receipt["artifacts"] = list(artifacts)
-    receipt["sources"] = nested_sources
+    receipt["sources"] = per_ingest_docs
     receipt["disagreements"] = disagreements
     receipt["version_drift"] = drift
     return receipt

--- a/src/monarch_ingest/release_metadata.py
+++ b/src/monarch_ingest/release_metadata.py
@@ -1,0 +1,162 @@
+"""Aggregate per-ingest `release-metadata.yaml` files into a monarch-kg build receipt.
+
+Each per-ingest file (a `kozahub_metadata_schema:ReleaseMetadata`) is rewritten
+as a nested `Release` (per the recursive shape in kozahub-metadata-schema): the
+top-level `source`/`source_version` becomes `id`/`version`. Leaf upstream
+`SourceVersion` records already use `id`/`version` and slot in unchanged.
+
+Cross-ingest version disagreements (same `infores:` consumed at different
+versions across contributing ingests) are surfaced at the top level of the
+aggregated document.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+from collections import defaultdict
+from pathlib import Path
+
+import yaml
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_per_ingest_metadata(input_dir: str | Path) -> list[dict]:
+    files = sorted(Path(input_dir).glob("*.yaml"))
+    return [yaml.safe_load(p.read_text()) for p in files]
+
+
+_NESTED_KEY_ORDER = (
+    "id",
+    "version",
+    "transform_version",
+    "biolink_version",
+    "build_version",
+    "generated_at",
+    "sources",
+    "artifacts",
+    "tools",
+)
+
+
+def to_nested_release(per_ingest: dict) -> dict:
+    """Promote a per-ingest `ReleaseMetadata` doc to a nested `Release`.
+
+    Renames `source` → `id` and `source_version` → `version`; everything else
+    (transform_version, biolink_version, build_version, generated_at, sources,
+    artifacts, tools) is already in the right shape.
+    """
+    promoted = dict(per_ingest)
+    promoted["id"] = promoted.pop("source")
+    if "source_version" in promoted:
+        promoted["version"] = promoted.pop("source_version")
+
+    ordered = {k: promoted[k] for k in _NESTED_KEY_ORDER if k in promoted}
+    for k, v in promoted.items():
+        if k not in ordered:
+            ordered[k] = v
+    return ordered
+
+
+# `version_method` values whose "version" is a moving snapshot timestamp
+# (not a stable release identifier). Skew across ingests on these methods is
+# expected — they're flagged as `version_drift` rather than `disagreements`.
+ROLLING_VERSION_METHODS = frozenset({"http_last_modified", "github_branch_head"})
+
+
+def find_disagreements(per_ingest_docs: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Bucket cross-ingest version mismatches by source stability.
+
+    Returns `(disagreements, version_drift)`:
+    - `disagreements`: any source seen at multiple versions where at least one
+      ingest used a tagged-release `version_method` — likely a real conflict.
+    - `version_drift`: mismatches across rolling sources only (e.g. NCBI's
+      `gene_info.gz` Last-Modified header advancing between fetches) — expected.
+    """
+    by_source: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+    for doc in per_ingest_docs:
+        ingest = doc.get("source")
+        for src in doc.get("sources") or []:
+            sid = src.get("id")
+            if sid:
+                by_source[sid].append((ingest, src.get("version"), src.get("version_method")))
+
+    disagreements: list[dict] = []
+    drift: list[dict] = []
+    for sid, observations in sorted(by_source.items()):
+        versions = {v for _, v, _ in observations}
+        if len(versions) <= 1:
+            continue
+        methods = {m for _, _, m in observations}
+        record = {
+            "id": sid,
+            "versions_observed": sorted(v for v in versions if v is not None),
+            "by_ingest": {ingest: ver for ingest, ver, _ in observations},
+        }
+        all_rolling = methods <= ROLLING_VERSION_METHODS and methods
+        if all_rolling:
+            drift.append(record)
+        else:
+            disagreements.append(record)
+    return disagreements, drift
+
+
+def aggregate(
+    input_dir: str | Path,
+    kg_name: str,
+    kg_version: str,
+    packages: dict | None = None,
+    artifacts: list[dict] | None = None,
+) -> dict:
+    """Read per-ingest metadata files and emit the consolidated build receipt.
+
+    Returned shape: a top-level `Release` with `id=kg_name`, `version=kg_version`,
+    nested `sources` (one per ingest, with their own leaves), plus `packages`
+    (legacy compatibility key for `tools`) and `disagreements` (computed across
+    the contributing builds).
+    """
+    per_ingest_docs = load_per_ingest_metadata(input_dir)
+    nested_sources = [to_nested_release(d) for d in per_ingest_docs]
+    disagreements, drift = find_disagreements(per_ingest_docs)
+
+    receipt: dict = {
+        "id": kg_name,
+        "version": kg_version,
+        "generated_at": _now_iso(),
+    }
+    if packages:
+        receipt["packages"] = dict(packages)
+    if artifacts:
+        receipt["artifacts"] = list(artifacts)
+    receipt["sources"] = nested_sources
+    receipt["disagreements"] = disagreements
+    receipt["version_drift"] = drift
+    return receipt
+
+
+def collect_kg_artifacts(output_dir: str | Path, names: list[str]) -> list[dict]:
+    """Build a list of `{path, sha256}` for the named files in output_dir."""
+    out_path = Path(output_dir)
+    artifacts = []
+    for name in names:
+        p = out_path / name
+        if not p.is_file():
+            continue
+        artifacts.append({"path": name, "sha256": _file_sha256(p)})
+    return artifacts
+
+
+def write_receipt(receipt: dict, output_path: str | Path) -> None:
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(output_path).write_text(yaml.safe_dump(receipt, sort_keys=False, default_flow_style=False))

--- a/src/monarch_ingest/release_metadata.py
+++ b/src/monarch_ingest/release_metadata.py
@@ -72,7 +72,11 @@ def to_nested_release(per_ingest: dict) -> dict:
 # `version_method` values whose "version" is a moving snapshot timestamp
 # (not a stable release identifier). Skew across ingests on these methods is
 # expected — they're flagged as `version_drift` rather than `disagreements`.
-ROLLING_VERSION_METHODS = frozenset({"http_last_modified", "github_branch_head"})
+ROLLING_VERSION_METHODS = frozenset({
+    "http_last_modified",
+    "github_branch_head",
+    "max_published_date",
+})
 
 
 def find_disagreements(per_ingest_docs: list[dict]) -> tuple[list[dict], list[dict]]:

--- a/src/monarch_ingest/utils/ingest_utils.py
+++ b/src/monarch_ingest/utils/ingest_utils.py
@@ -7,20 +7,37 @@ from monarch_ingest.utils.log_utils import get_logger
 
 
 RELEASE_ASSET_URL = "https://github.com/monarch-initiative/{repo}/releases/latest/download/{file}"
+DEFAULT_METADATA_URL = (
+    "https://github.com/monarch-initiative/{repo}/releases/latest/download/release-metadata.yaml"
+)
 
 
 def get_ingests():
     return yaml.safe_load(pkgutil.get_data("monarch_ingest", "ingests.yaml"))
 
 
-def get_release_metadata_repos():
-    """Repos contributing to the build receipt — derived from kozahub-style entries."""
-    seen = []
+def get_release_metadata_sources():
+    """`(repo, metadata_url)` for each kozahub-style entry contributing to the receipt.
+
+    Honors a per-entry `metadata_url:` override; otherwise falls back to the
+    standard GitHub-releases asset URL. Deduplicates by repo (first seen wins).
+    """
+    seen: dict[str, str] = {}
     for entry in get_ingests().values():
-        repo = entry.get("repo") if isinstance(entry, dict) else None
-        if repo and repo not in seen:
-            seen.append(repo)
-    return seen
+        if not isinstance(entry, dict):
+            continue
+        repo = entry.get("repo")
+        if not repo or repo in seen:
+            continue
+        seen[repo] = entry.get("metadata_url") or DEFAULT_METADATA_URL.format(repo=repo)
+    return list(seen.items())
+
+
+def is_metadata_only(entry: dict) -> bool:
+    """An entry that contributes only to the build receipt — no download, no transform."""
+    if not isinstance(entry, dict):
+        return False
+    return "repo" in entry and not entry.get("files") and "url" not in entry and "config" not in entry
 
 
 def ingest_urls(entry: dict) -> list:

--- a/src/monarch_ingest/utils/ingest_utils.py
+++ b/src/monarch_ingest/utils/ingest_utils.py
@@ -6,8 +6,35 @@ import yaml
 from monarch_ingest.utils.log_utils import get_logger
 
 
+RELEASE_ASSET_URL = "https://github.com/monarch-initiative/{repo}/releases/latest/download/{file}"
+
+
 def get_ingests():
     return yaml.safe_load(pkgutil.get_data("monarch_ingest", "ingests.yaml"))
+
+
+def get_release_metadata_repos():
+    """Repos contributing to the build receipt — derived from kozahub-style entries."""
+    seen = []
+    for entry in get_ingests().values():
+        repo = entry.get("repo") if isinstance(entry, dict) else None
+        if repo and repo not in seen:
+            seen.append(repo)
+    return seen
+
+
+def ingest_urls(entry: dict) -> list:
+    """Resolve an ingest entry to its list of download URLs.
+
+    Handles both `url:`-style (explicit URLs) and `repo:`+`files:`-style
+    (kozahub ingest, URLs derived from the GitHub release).
+    """
+    if "url" in entry:
+        return list(entry["url"] or [])
+    if "repo" in entry:
+        repo = entry["repo"]
+        return [RELEASE_ASSET_URL.format(repo=repo, file=f) for f in entry.get("files", []) or []]
+    return []
 
 
 def get_qc_expectations():

--- a/tests/test_ingest_utils.py
+++ b/tests/test_ingest_utils.py
@@ -3,7 +3,13 @@
 import os
 from unittest.mock import patch
 
-from monarch_ingest.utils.ingest_utils import file_exists, ingest_output_exists, get_ingests, get_qc_expectations
+from monarch_ingest.utils.ingest_utils import (
+    file_exists,
+    ingest_output_exists,
+    get_ingests,
+    get_qc_expectations,
+    get_release_metadata_repos,
+)
 
 
 class TestFileExists:
@@ -131,6 +137,55 @@ class TestGetIngests:
     def test_known_ingest_present(self):
         result = get_ingests()
         assert "hgnc_gene" in result
+
+
+class TestGetReleaseMetadataRepos:
+    def test_derives_unique_repos_from_kozahub_entries(self):
+        repos = get_release_metadata_repos()
+        assert isinstance(repos, list)
+        assert "alliance-ingest" in repos
+        assert "ncbi-gene" in repos
+        # Deduplicated even though alliance-ingest appears in many transforms.
+        assert len(repos) == len(set(repos))
+        # maxo-annotation-ingest is not consumed by any transform — must not appear.
+        assert "maxo-annotation-ingest" not in repos
+        # alliance-disease-association-ingest was an oversight; alliance disease now comes from alliance-ingest.
+        assert "alliance-disease-association-ingest" not in repos
+
+
+class TestDownloadReleaseMetadata:
+    def test_writes_files_skips_404_and_errors(self, tmp_path):
+        from unittest.mock import MagicMock
+        import requests
+
+        from monarch_ingest.cli_utils import download_release_metadata
+
+        ok_resp = MagicMock(status_code=200, ok=True, content=b"source: foo\n")
+        miss_resp = MagicMock(status_code=404, ok=False)
+        bad_resp = MagicMock(status_code=500, ok=False)
+
+        responses = {
+            "https://github.com/monarch-initiative/foo/releases/latest/download/release-metadata.yaml": ok_resp,
+            "https://github.com/monarch-initiative/missing/releases/latest/download/release-metadata.yaml": miss_resp,
+            "https://github.com/monarch-initiative/broken/releases/latest/download/release-metadata.yaml": bad_resp,
+        }
+
+        def fake_get(url, **_kwargs):
+            if "boom" in url:
+                raise requests.ConnectionError("nope")
+            return responses[url]
+
+        with patch("monarch_ingest.cli_utils.requests.get", side_effect=fake_get):
+            written = download_release_metadata(
+                repos=["foo", "missing", "broken", "boom"],
+                output_dir=str(tmp_path),
+            )
+
+        assert written == ["foo"]
+        assert (tmp_path / "foo.yaml").read_bytes() == b"source: foo\n"
+        assert not (tmp_path / "missing.yaml").exists()
+        assert not (tmp_path / "broken.yaml").exists()
+        assert not (tmp_path / "boom.yaml").exists()
 
 
 class TestGetQcExpectations:

--- a/tests/test_ingest_utils.py
+++ b/tests/test_ingest_utils.py
@@ -8,7 +8,8 @@ from monarch_ingest.utils.ingest_utils import (
     ingest_output_exists,
     get_ingests,
     get_qc_expectations,
-    get_release_metadata_repos,
+    get_release_metadata_sources,
+    is_metadata_only,
 )
 
 
@@ -139,10 +140,11 @@ class TestGetIngests:
         assert "hgnc_gene" in result
 
 
-class TestGetReleaseMetadataRepos:
-    def test_derives_unique_repos_from_kozahub_entries(self):
-        repos = get_release_metadata_repos()
-        assert isinstance(repos, list)
+class TestGetReleaseMetadataSources:
+    def test_derives_unique_sources_from_kozahub_entries(self):
+        sources = get_release_metadata_sources()
+        assert isinstance(sources, list)
+        repos = [r for r, _ in sources]
         assert "alliance-ingest" in repos
         assert "ncbi-gene" in repos
         # Deduplicated even though alliance-ingest appears in many transforms.
@@ -151,6 +153,28 @@ class TestGetReleaseMetadataRepos:
         assert "maxo-annotation-ingest" not in repos
         # alliance-disease-association-ingest was an oversight; alliance disease now comes from alliance-ingest.
         assert "alliance-disease-association-ingest" not in repos
+        # Default URL when no override.
+        alliance_url = dict(sources)["alliance-ingest"]
+        assert alliance_url == (
+            "https://github.com/monarch-initiative/alliance-ingest/releases/latest/download/release-metadata.yaml"
+        )
+
+    def test_metadata_url_override_is_honored(self):
+        sources = dict(get_release_metadata_sources())
+        # kg-phenio is published to KG-Hub S3, not GitHub releases.
+        assert sources.get("kg-phenio") == (
+            "https://kg-hub.berkeleybop.io/kg-phenio/current/release-metadata.yaml"
+        )
+
+
+class TestIsMetadataOnly:
+    def test_kg_phenio_is_metadata_only(self):
+        ingests = get_ingests()
+        assert is_metadata_only(ingests["kg_phenio"])
+
+    def test_kozahub_entries_with_files_are_not_metadata_only(self):
+        ingests = get_ingests()
+        assert not is_metadata_only(ingests["alliance_gene"])
 
 
 class TestDownloadReleaseMetadata:
@@ -163,11 +187,13 @@ class TestDownloadReleaseMetadata:
         ok_resp = MagicMock(status_code=200, ok=True, content=b"source: foo\n")
         miss_resp = MagicMock(status_code=404, ok=False)
         bad_resp = MagicMock(status_code=500, ok=False)
+        custom_resp = MagicMock(status_code=200, ok=True, content=b"source: kg-phenio\n")
 
         responses = {
             "https://github.com/monarch-initiative/foo/releases/latest/download/release-metadata.yaml": ok_resp,
             "https://github.com/monarch-initiative/missing/releases/latest/download/release-metadata.yaml": miss_resp,
             "https://github.com/monarch-initiative/broken/releases/latest/download/release-metadata.yaml": bad_resp,
+            "https://kg-hub.example/kg-phenio/release-metadata.yaml": custom_resp,
         }
 
         def fake_get(url, **_kwargs):
@@ -177,12 +203,19 @@ class TestDownloadReleaseMetadata:
 
         with patch("monarch_ingest.cli_utils.requests.get", side_effect=fake_get):
             written = download_release_metadata(
-                repos=["foo", "missing", "broken", "boom"],
+                sources=[
+                    ("foo", "https://github.com/monarch-initiative/foo/releases/latest/download/release-metadata.yaml"),
+                    ("missing", "https://github.com/monarch-initiative/missing/releases/latest/download/release-metadata.yaml"),
+                    ("broken", "https://github.com/monarch-initiative/broken/releases/latest/download/release-metadata.yaml"),
+                    ("boom", "https://github.com/monarch-initiative/boom/releases/latest/download/release-metadata.yaml"),
+                    ("kg-phenio", "https://kg-hub.example/kg-phenio/release-metadata.yaml"),
+                ],
                 output_dir=str(tmp_path),
             )
 
-        assert written == ["foo"]
+        assert written == ["foo", "kg-phenio"]
         assert (tmp_path / "foo.yaml").read_bytes() == b"source: foo\n"
+        assert (tmp_path / "kg-phenio.yaml").read_bytes() == b"source: kg-phenio\n"
         assert not (tmp_path / "missing.yaml").exists()
         assert not (tmp_path / "broken.yaml").exists()
         assert not (tmp_path / "boom.yaml").exists()

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -5,7 +5,6 @@ import yaml
 from monarch_ingest.release_metadata import (
     aggregate,
     find_disagreements,
-    to_nested_release,
 )
 
 
@@ -13,27 +12,11 @@ def _write(p, doc):
     p.write_text(yaml.safe_dump(doc, sort_keys=False))
 
 
-def test_to_nested_release_renames_top_level_keys():
-    per_ingest = {
-        "source": "alliance-ingest",
-        "source_version": "8.3.0",
-        "transform_version": "abc123",
-        "build_version": "alliance-ingest_8.3.0_abc123_4.3.9",
-    }
-    nested = to_nested_release(per_ingest)
-    assert nested["id"] == "alliance-ingest"
-    assert nested["version"] == "8.3.0"
-    assert "source" not in nested
-    assert "source_version" not in nested
-    # id and version come first, preserving readable order.
-    assert list(nested.keys())[:2] == ["id", "version"]
-
-
 def test_find_disagreements_flags_tagged_version_skew():
     docs = [
-        {"source": "a", "sources": [{"id": "infores:hgnc", "version": "2026-04-01", "version_method": "url_path"}]},
-        {"source": "b", "sources": [{"id": "infores:hgnc", "version": "2026-05-01", "version_method": "url_path"}]},
-        {"source": "c", "sources": [{"id": "infores:agr", "version": "8.3.0", "version_method": "alliance_fms_api"}]},
+        {"id": "a", "sources": [{"id": "infores:hgnc", "version": "2026-04-01", "version_method": "url_path"}]},
+        {"id": "b", "sources": [{"id": "infores:hgnc", "version": "2026-05-01", "version_method": "url_path"}]},
+        {"id": "c", "sources": [{"id": "infores:agr", "version": "8.3.0", "version_method": "alliance_fms_api"}]},
     ]
     disagreements, drift = find_disagreements(docs)
     assert drift == []
@@ -46,8 +29,8 @@ def test_find_disagreements_flags_tagged_version_skew():
 
 def test_find_disagreements_buckets_rolling_drift_separately():
     docs = [
-        {"source": "a", "sources": [{"id": "infores:ncbi-gene", "version": "2026-05-01", "version_method": "http_last_modified"}]},
-        {"source": "b", "sources": [{"id": "infores:ncbi-gene", "version": "2026-05-02", "version_method": "http_last_modified"}]},
+        {"id": "a", "sources": [{"id": "infores:ncbi-gene", "version": "2026-05-01", "version_method": "http_last_modified"}]},
+        {"id": "b", "sources": [{"id": "infores:ncbi-gene", "version": "2026-05-02", "version_method": "http_last_modified"}]},
     ]
     disagreements, drift = find_disagreements(docs)
     assert disagreements == []
@@ -58,8 +41,8 @@ def test_find_disagreements_buckets_rolling_drift_separately():
 def test_find_disagreements_mixed_methods_treated_as_hard():
     # If even one consumer captured the source via a tagged method, treat as a real disagreement.
     docs = [
-        {"source": "a", "sources": [{"id": "infores:foo", "version": "1", "version_method": "http_last_modified"}]},
-        {"source": "b", "sources": [{"id": "infores:foo", "version": "2", "version_method": "url_path"}]},
+        {"id": "a", "sources": [{"id": "infores:foo", "version": "1", "version_method": "http_last_modified"}]},
+        {"id": "b", "sources": [{"id": "infores:foo", "version": "2", "version_method": "url_path"}]},
     ]
     disagreements, drift = find_disagreements(docs)
     assert drift == []
@@ -68,16 +51,16 @@ def test_find_disagreements_mixed_methods_treated_as_hard():
 
 def test_find_disagreements_clean_when_versions_match():
     docs = [
-        {"source": "a", "sources": [{"id": "infores:hgnc", "version": "2026-05-01", "version_method": "url_path"}]},
-        {"source": "b", "sources": [{"id": "infores:hgnc", "version": "2026-05-01", "version_method": "url_path"}]},
+        {"id": "a", "sources": [{"id": "infores:hgnc", "version": "2026-05-01", "version_method": "url_path"}]},
+        {"id": "b", "sources": [{"id": "infores:hgnc", "version": "2026-05-01", "version_method": "url_path"}]},
     ]
     assert find_disagreements(docs) == ([], [])
 
 
 def test_aggregate_emits_release_shape(tmp_path):
     _write(tmp_path / "alliance-ingest.yaml", {
-        "source": "alliance-ingest",
-        "source_version": "8.3.0",
+        "id": "alliance-ingest",
+        "version": "8.3.0",
         "transform_version": "abc",
         "biolink_version": "4.3.9",
         "build_version": "alliance-ingest_8.3.0_abc_4.3.9",
@@ -107,3 +90,43 @@ def test_aggregate_emits_release_shape(tmp_path):
     assert nested["sources"][0]["id"] == "infores:agr"
     assert receipt["disagreements"] == []
     assert receipt["version_drift"] == []
+
+
+def test_aggregate_handles_kg_phenio_recursive_shape(tmp_path):
+    """kg-phenio's release-metadata.yaml has phenio nested as a Release whose
+    own sources are the upstream ontologies — verify the aggregator preserves
+    the recursive structure verbatim under monarch-kg."""
+    _write(tmp_path / "kg-phenio.yaml", {
+        "id": "kg-phenio",
+        "version": "v2026-05-06",
+        "transform_version": "deadbeef",
+        "biolink_version": "4.3.9",
+        "build_version": "kg-phenio_v2026-05-06_deadbeef_4.3.9",
+        "generated_at": "2026-05-06T00:00:00Z",
+        "sources": [
+            {
+                "id": "phenio",
+                "name": "PHENIO",
+                "version": "v2026-05-06",
+                "version_method": "github_release_api",
+                "sources": [
+                    {"id": "infores:bfo", "version": "2019-08-26", "version_method": "owl_version_iri"},
+                    {"id": "infores:chebi", "version": "2026-04-20", "version_method": "owl_version_iri"},
+                ],
+            },
+        ],
+    })
+
+    receipt = aggregate(
+        input_dir=tmp_path,
+        kg_name="monarch-kg",
+        kg_version="2026-05-06",
+    )
+
+    assert len(receipt["sources"]) == 1
+    kgp = receipt["sources"][0]
+    assert kgp["id"] == "kg-phenio"
+    # Phenio's nested ontology Releases survive verbatim under kg-phenio.
+    phenio = kgp["sources"][0]
+    assert phenio["id"] == "phenio"
+    assert {s["id"] for s in phenio["sources"]} == {"infores:bfo", "infores:chebi"}

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,109 @@
+"""Tests for monarch_ingest.release_metadata."""
+
+import yaml
+
+from monarch_ingest.release_metadata import (
+    aggregate,
+    find_disagreements,
+    to_nested_release,
+)
+
+
+def _write(p, doc):
+    p.write_text(yaml.safe_dump(doc, sort_keys=False))
+
+
+def test_to_nested_release_renames_top_level_keys():
+    per_ingest = {
+        "source": "alliance-ingest",
+        "source_version": "8.3.0",
+        "transform_version": "abc123",
+        "build_version": "alliance-ingest_8.3.0_abc123_4.3.9",
+    }
+    nested = to_nested_release(per_ingest)
+    assert nested["id"] == "alliance-ingest"
+    assert nested["version"] == "8.3.0"
+    assert "source" not in nested
+    assert "source_version" not in nested
+    # id and version come first, preserving readable order.
+    assert list(nested.keys())[:2] == ["id", "version"]
+
+
+def test_find_disagreements_flags_tagged_version_skew():
+    docs = [
+        {"source": "a", "sources": [{"id": "infores:hgnc", "version": "2026-04-01", "version_method": "url_path"}]},
+        {"source": "b", "sources": [{"id": "infores:hgnc", "version": "2026-05-01", "version_method": "url_path"}]},
+        {"source": "c", "sources": [{"id": "infores:agr", "version": "8.3.0", "version_method": "alliance_fms_api"}]},
+    ]
+    disagreements, drift = find_disagreements(docs)
+    assert drift == []
+    assert len(disagreements) == 1
+    d = disagreements[0]
+    assert d["id"] == "infores:hgnc"
+    assert d["versions_observed"] == ["2026-04-01", "2026-05-01"]
+    assert d["by_ingest"] == {"a": "2026-04-01", "b": "2026-05-01"}
+
+
+def test_find_disagreements_buckets_rolling_drift_separately():
+    docs = [
+        {"source": "a", "sources": [{"id": "infores:ncbi-gene", "version": "2026-05-01", "version_method": "http_last_modified"}]},
+        {"source": "b", "sources": [{"id": "infores:ncbi-gene", "version": "2026-05-02", "version_method": "http_last_modified"}]},
+    ]
+    disagreements, drift = find_disagreements(docs)
+    assert disagreements == []
+    assert len(drift) == 1
+    assert drift[0]["id"] == "infores:ncbi-gene"
+
+
+def test_find_disagreements_mixed_methods_treated_as_hard():
+    # If even one consumer captured the source via a tagged method, treat as a real disagreement.
+    docs = [
+        {"source": "a", "sources": [{"id": "infores:foo", "version": "1", "version_method": "http_last_modified"}]},
+        {"source": "b", "sources": [{"id": "infores:foo", "version": "2", "version_method": "url_path"}]},
+    ]
+    disagreements, drift = find_disagreements(docs)
+    assert drift == []
+    assert len(disagreements) == 1
+
+
+def test_find_disagreements_clean_when_versions_match():
+    docs = [
+        {"source": "a", "sources": [{"id": "infores:hgnc", "version": "2026-05-01", "version_method": "url_path"}]},
+        {"source": "b", "sources": [{"id": "infores:hgnc", "version": "2026-05-01", "version_method": "url_path"}]},
+    ]
+    assert find_disagreements(docs) == ([], [])
+
+
+def test_aggregate_emits_release_shape(tmp_path):
+    _write(tmp_path / "alliance-ingest.yaml", {
+        "source": "alliance-ingest",
+        "source_version": "8.3.0",
+        "transform_version": "abc",
+        "biolink_version": "4.3.9",
+        "build_version": "alliance-ingest_8.3.0_abc_4.3.9",
+        "generated_at": "2026-05-02T00:00:00Z",
+        "sources": [{"id": "infores:agr", "version": "8.3.0", "urls": ["https://example.org/x"]}],
+        "artifacts": [{"path": "alliance_gene_nodes.tsv", "sha256": "deadbeef"}],
+        "tools": {"koza": "2.3.0"},
+    })
+
+    receipt = aggregate(
+        input_dir=tmp_path,
+        kg_name="monarch-kg",
+        kg_version="2026-05-02",
+        packages={"biolink": "4.3.9", "koza": "2.3.0"},
+        artifacts=[{"path": "monarch-kg.tar.gz", "sha256": "cafef00d"}],
+    )
+
+    assert receipt["id"] == "monarch-kg"
+    assert receipt["version"] == "2026-05-02"
+    assert receipt["packages"] == {"biolink": "4.3.9", "koza": "2.3.0"}
+    assert receipt["artifacts"][0]["path"] == "monarch-kg.tar.gz"
+    assert len(receipt["sources"]) == 1
+
+    nested = receipt["sources"][0]
+    assert nested["id"] == "alliance-ingest"
+    assert nested["version"] == "8.3.0"
+    assert nested["sources"][0]["id"] == "infores:agr"
+    assert receipt["disagreements"] == []
+    assert receipt["version_drift"] == []

--- a/tests/test_yaml_configs.py
+++ b/tests/test_yaml_configs.py
@@ -1,6 +1,6 @@
 """Smoke tests validating config file integrity for ingests.yaml and qc_expect.yaml."""
 
-from monarch_ingest.utils.ingest_utils import get_ingests, get_qc_expectations
+from monarch_ingest.utils.ingest_utils import get_ingests, get_qc_expectations, ingest_urls
 
 
 class TestIngestsYaml:
@@ -9,20 +9,24 @@ class TestIngestsYaml:
         assert isinstance(ingests, dict)
         assert len(ingests) > 0
 
-    def test_every_ingest_has_url_or_config(self):
+    def test_every_ingest_has_known_shape(self):
         ingests = get_ingests()
         for name, entry in ingests.items():
-            assert "url" in entry or "config" in entry, (
-                f"Ingest '{name}' has neither 'url' nor 'config'"
+            has_known_shape = "url" in entry or "config" in entry or "repo" in entry
+            assert has_known_shape, (
+                f"Ingest '{name}' has none of 'url', 'config', or 'repo'"
             )
+
+    def test_repo_entries_have_files(self):
+        ingests = get_ingests()
+        for name, entry in ingests.items():
+            if "repo" in entry:
+                assert entry.get("files"), f"Ingest '{name}' has 'repo' but no 'files'"
 
     def test_all_urls_are_https(self):
         ingests = get_ingests()
         for name, entry in ingests.items():
-            urls = entry.get("url", [])
-            if urls is None:
-                continue
-            for url in urls:
+            for url in ingest_urls(entry):
                 assert url.startswith("https://"), (
                     f"Ingest '{name}' has non-https URL: {url}"
                 )
@@ -31,10 +35,7 @@ class TestIngestsYaml:
         """All ingest source URLs must be TSV or JSONL files."""
         ingests = get_ingests()
         for name, entry in ingests.items():
-            urls = entry.get("url", [])
-            if urls is None:
-                continue
-            for url in urls:
+            for url in ingest_urls(entry):
                 assert url.endswith(".tsv") or url.endswith(".jsonl"), (
                     f"Ingest '{name}' has URL with unsupported extension: {url}"
                 )

--- a/tests/test_yaml_configs.py
+++ b/tests/test_yaml_configs.py
@@ -17,11 +17,15 @@ class TestIngestsYaml:
                 f"Ingest '{name}' has none of 'url', 'config', or 'repo'"
             )
 
-    def test_repo_entries_have_files(self):
+    def test_repo_entries_have_files_or_metadata_url(self):
+        """A `repo:` entry either has `files:` (a transform target) or
+        `metadata_url:` (a metadata-only contribution to the build receipt)."""
         ingests = get_ingests()
         for name, entry in ingests.items():
             if "repo" in entry:
-                assert entry.get("files"), f"Ingest '{name}' has 'repo' but no 'files'"
+                assert entry.get("files") or entry.get("metadata_url"), (
+                    f"Ingest '{name}' has 'repo' but neither 'files' nor 'metadata_url'"
+                )
 
     def test_all_urls_are_https(self):
         ingests = get_ingests()


### PR DESCRIPTION
## Summary
- New `ingest download-release-metadata` fetches each kozahub ingest repo's `release-metadata.yaml` GitHub release asset into `data/release-metadata/`.
- New `ingest build-receipt` aggregates those files into a single `output/metadata.yaml` shaped as a recursive `Release` (kozahub-metadata-schema). Per-ingest top-level `source`/`source_version` are renamed to `id`/`version` when nested.
- `ingests.yaml` gains a third entry shape (`repo:` + `files:`) for kozahub ingests; URLs derive from the standard GitHub-release path. The set of metadata-producing repos is implicit from these entries.
- Cross-ingest version skew is bucketed: `disagreements` (tagged release methods — `url_path`, `github_release_api`, etc.) vs `version_drift` (rolling methods — `http_last_modified`, `github_branch_head`). Both surface as warnings — they're descriptive signal, not build gates.
- Jenkinsfile + `build_mokg.sh` are wired to call `download-release-metadata` in the download stage and `build-receipt` after merge. The legacy `--write-metadata` flag and `get_pkg_versions`/`get_data_versions` helpers are retired (their output is superseded).

Depends on the new `Release` class in [kozahub-metadata-schema PR #6](https://github.com/monarch-initiative/kozahub-metadata-schema/pull/6) (merged).

## Test plan
- [x] 34 unit tests pass (10 new): loader split, URL resolver, fetcher branches (success/404/error/exception), aggregator nesting, disagreement vs drift bucketing.
- [x] Live: `download-release-metadata` fetched 23/23 repos. `build-receipt` produced a valid receipt with 23 nested ingest sources, 0 disagreements, 1 rolling-source drift (NCBI `gene_info.gz` Last-Modified between two ingests' fetches — exactly the kind of benign drift the rolling bucket is for).
- [ ] Jenkins pipeline-level validation pending production build.