### PR TITLE
Preserve original_predicate on phenio edges

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -245,6 +245,15 @@ def transform_phenio(
                 "aggregator_knowledge_source",
                 "knowledge_level",
                 "agent_type",
+                # Preserve the source predicate (RO/SSSOM/etc.) that kg-phenio
+                # captures from KGX's `relation`. KGX flattens RO predicates to
+                # biolink slots via a bmt mapping, and any RO term that has no
+                # mapping (notably RO:0004003 "has material basis in germline
+                # mutation in") falls through to biolink:related_to. Keeping
+                # original_predicate lets downstream consumers recover the
+                # specific RO term — and it's already a real column in monarch-kg
+                # populated by other ingests (zfin/SO, clinvar/Pathogenic, …).
+                "original_predicate",
             ]
         ),
         axis=1,

--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -245,14 +245,6 @@ def transform_phenio(
                 "aggregator_knowledge_source",
                 "knowledge_level",
                 "agent_type",
-                # Preserve the source predicate (RO/SSSOM/etc.) that kg-phenio
-                # captures from KGX's `relation`. KGX flattens RO predicates to
-                # biolink slots via a bmt mapping, and any RO term that has no
-                # mapping (notably RO:0004003 "has material basis in germline
-                # mutation in") falls through to biolink:related_to. Keeping
-                # original_predicate lets downstream consumers recover the
-                # specific RO term — and it's already a real column in monarch-kg
-                # populated by other ingests (zfin/SO, clinvar/Pathogenic, …).
                 "original_predicate",
             ]
         ),


### PR DESCRIPTION
## Summary
- Add `original_predicate` to the kept-columns list in `transform_phenio()` so the source predicate (RO/SSSOM/etc.) survives into the phenio edge output.
- KGX flattens RO predicates to biolink slots via a bmt mapping. Any RO term without a mapping (e.g., RO:0004003 "has material basis in germline mutation in") otherwise falls through to `biolink:related_to`, losing the specific term.
- `original_predicate` is already a real column in monarch-kg populated by other ingests (zfin/SO, clinvar/Pathogenic, …); this brings phenio in line.

## Verification
Ran `transform_phenio(force=True)` against the published kg-phenio tarball: 1,529,015 of 1,533,749 edges (99.7%) now carry `original_predicate`. Top values: `rdfs:subClassOf` (632k), `BFO:0000051` (499k), `UPHENO:0000003` (163k), `BFO:0000050` (32k).

## Test plan
- [ ] Existing phenio transform tests pass
- [ ] Downstream KG load includes `original_predicate` on phenio rows