### PR TITLE
Fix qc_expect/qc_report mismatch: ncbi_gene per-species + group_by provided_by

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -506,12 +506,15 @@ def _merge_files_koza(
         for exported_file in result.exported_files:
             logger.info(f"Exported archive: {exported_file}")
 
-    # Generate QC report (group by file_source for compatibility with qc_expect.yaml)
+    # Group by provided_by. Koza's merge currently overrides both provided_by
+    # and file_source to the per-TSV name, so the two are functionally identical
+    # here, but provided_by is the semantically correct axis (qc_expect.yaml
+    # keys are organized under `provided_by:`).
     logger.info("Generating QC report...")
     qc_config = QCReportConfig(
         database_path=database_path,
         output_file=Path(output_dir) / "qc_report.yaml",
-        group_by="file_source",
+        group_by="provided_by",
         quiet=not verbose if verbose is not None else True,
     )
     generate_qc_report(qc_config)

--- a/src/monarch_ingest/qc_expect.yaml
+++ b/src/monarch_ingest/qc_expect.yaml
@@ -10,8 +10,19 @@ nodes:
       min: 14000
     hgnc_gene_nodes:
       min: 43000
-    ncbi_gene_nodes:
-      min: 190000
+    # Koza merge labels rows by per-TSV file_source / provided_by; ncbi-gene
+    # publishes per-species KGX TSVs, so the qc_report ends up with one row
+    # per species. Mins set ~at current per-species counts; <70% errors.
+    ncbi_gene_227321_nodes:
+      min: 10000
+    ncbi_gene_9031_nodes:
+      min: 30000
+    ncbi_gene_9615_nodes:
+      min: 48000
+    ncbi_gene_9823_nodes:
+      min: 43000
+    ncbi_gene_9913_nodes:
+      min: 54000
 
     phenio_nodes:
       min: 288000
@@ -32,7 +43,7 @@ nodes:
 edges:
   provided_by:
     alliance_gene_to_expression_edges:
-      min: 1870000
+      min: 1900000
     alliance_genotype_edges:
       min: 260000
     alliance_allele_edges:


### PR DESCRIPTION
## Problem

`ingest merge` exits non-zero on the qc-validation gate (`validate_qc_counts` → `sys.exit(1)` in `main.py:266`) because the consolidated `ncbi_gene_nodes` entry in `qc_expect.yaml` has no matching row in `qc_report.yaml`:

```
ERROR | nodes ncbi_gene_nodes not found in qc_report.yaml
```

## Root cause

Two interacting things, neither obviously wrong on its own:

1. **Koza's merge labels per-TSV.** Both the `provided_by` and `file_source` columns of the merged `nodes` table get overridden to the source TSV's basename. ncbi-gene publishes five per-species TSVs (`ncbi_gene_9615_nodes.tsv` etc.), so the merged table ends up with five distinct `provided_by` values. Verified by querying the merged DuckDB directly:
   ```
   ncbi_gene_227321_nodes  10567
   ncbi_gene_9031_nodes    32177
   ncbi_gene_9615_nodes    50757
   ncbi_gene_9823_nodes    45367
   ncbi_gene_9913_nodes    57273
   ```
   So `SELECT DISTINCT provided_by` (which is what `generate_qc_report` does) can never aggregate to a single `ncbi_gene_nodes` row under current koza behavior.

2. **`cli_utils.py` says `group_by="file_source"`** with a comment claiming "for compatibility with qc_expect.yaml" — but qc_expect.yaml's keys live under `provided_by:`, so the axis was inverted relative to the structure. (In practice it didn't matter since both columns hold the same per-TSV value, but the comment was misleading and would mask any future divergence.)

## Fix

- **`qc_expect.yaml`**: split the consolidated `ncbi_gene_nodes` entry into the five per-species entries that actually appear in qc_report. Mins set at roughly the current per-species counts; `<70%` errors via the existing check logic.
- **`cli_utils.py`**: `group_by="provided_by"` with a comment that describes what's actually happening, instead of the inverted "compatibility" claim.
- **`alliance_gene_to_expression_edges` min**: bumped 1_870_000 → 1_900_000 to track the current production count (local merge measured 1,955,138).

## Verification

Ran `rm -rf output/transform_output && ingest transform --all && ingest merge --closure` end-to-end against this branch:

```
Merge step took 165.00 seconds
Closure step took 99.64 seconds
validate_qc_counts returned error: False
```

qc_report has 18 node sources and 70 edge sources — all qc_expect keys matched, no warnings.

## Out of scope

- The koza-side oddity that `group_by` parameter has no observable effect (both columns hold per-TSV values) is worth a follow-up upstream if anyone wants real cross-TSV aggregation expressible from qc_expect.
- A separate June 3 production run reported `alliance_gene_to_expression_edges` at 1.45M — that's a data-source state issue (the local count this PR was tuned against is 1.96M), not something this PR can address.