### PR TITLE
Move _solr_edges materialization to an explicit `ingest prepare-solr` step, ahead of the parallel fan-out

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,14 @@ pipeline {
                 sh 'uv run ingest neo4j-csv'
             }
         }
+        // Materialize `_solr_edges` here so the parallel-processing stages
+        // (including solr) can all open monarch-kg.duckdb read-only without
+        // racing on a write lock.
+        stage('prepare-solr') {
+            steps {
+                sh 'uv run ingest prepare-solr'
+            }
+        }
         stage('parallel-processing') {
             parallel {
                 stage('kgx-graph-summary') {

--- a/scripts/load_solr.sh
+++ b/scripts/load_solr.sh
@@ -103,34 +103,20 @@ curl -X POST -H 'Content-Type: application/json' \
 
 uv run lsolr bulkload-db -C sssom -s model.yaml output/monarch-kg.duckdb mappings
 
-# Materialize the edges with `frequency_computed_sortable_float` — the
-# derived field the Solr UI sorts on to rank phenotypes by prevalence.
-# Previously this was set by a per-doc StatelessScriptUpdateProcessorFactory
-# (Nashorn JS) on the association core, which dominated load time. Doing it
-# once, vectorised in DuckDB, lets the edges load run substantially faster.
-# Mapping mirrors HPO's frequency sub-ontology (HP:0040280..HP:0040285) and
-# matches the legacy JS processor's outputs; rows with neither `has_quotient`
-# nor a known `frequency_qualifier` get 0.0, same as before.
-echo "Materializing edges with frequency_computed_sortable_float..."
+# `_solr_edges` (denormalized_edges + frequency_computed_sortable_float) is
+# materialized by `ingest prepare-solr`, run sequentially before this stage,
+# so we open the duckdb strictly read-only here — necessary because the
+# Jenkinsfile fans this stage out in parallel with kgx-graph-summary /
+# connectivity-report / kgx-transforms / neo4j-dump / sqlite, which would all
+# race on the file lock otherwise. Fail loud if the precondition isn't met.
+echo "Verifying _solr_edges was materialized by prepare-solr..."
 uv run python -c "
-import duckdb
-db = duckdb.connect('output/monarch-kg.duckdb')
-db.execute('''
-    CREATE OR REPLACE TABLE _solr_edges AS
-    SELECT *,
-           CASE
-             WHEN has_quotient IS NOT NULL THEN CAST(has_quotient AS DOUBLE)
-             WHEN frequency_qualifier = 'HP:0040280' THEN 1.0
-             WHEN frequency_qualifier = 'HP:0040281' THEN 0.8
-             WHEN frequency_qualifier = 'HP:0040282' THEN 0.3
-             WHEN frequency_qualifier = 'HP:0040283' THEN 0.05
-             WHEN frequency_qualifier = 'HP:0040284' THEN 0.01
-             WHEN frequency_qualifier = 'HP:0040285' THEN 0.0
-             ELSE 0.0
-           END AS frequency_computed_sortable_float
-    FROM denormalized_edges
-''')
-print('Done.')
+import duckdb, sys
+con = duckdb.connect('output/monarch-kg.duckdb', read_only=True)
+rows = con.execute(\"SELECT 1 FROM information_schema.tables WHERE table_name='_solr_edges'\").fetchall()
+if not rows:
+    sys.exit('ERROR: _solr_edges not found - run \\\"ingest prepare-solr\\\" first.')
+print('_solr_edges present.')
 "
 
 echo "Loading entities"

--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -578,6 +578,54 @@ def apply_closure(
     logger.info(f"Schema artifact written to {schema_yaml_path}")
 
 
+def prepare_solr(
+    name: str = "monarch-kg",
+    output_dir: str = OUTPUT_DIR,
+):
+    """Materialize `_solr_edges` in the merged DuckDB ahead of the Solr load.
+
+    `_solr_edges` is `denormalized_edges` plus `frequency_computed_sortable_float`
+    — the field the Solr UI sorts phenotypes by prevalence on. Previously a
+    per-doc Nashorn JS update processor on the association core handled this
+    during indexing; doing it once, vectorised in DuckDB, is dramatically
+    faster. Mapping mirrors HPO's frequency sub-ontology
+    (HP:0040280..HP:0040285); rows without a quotient or known frequency
+    qualifier get 0.0, matching the legacy processor.
+
+    Split out as its own step because the Jenkinsfile fans the post-merge work
+    out across parallel stages (kgx-graph-summary, connectivity-report, solr,
+    kgx-transforms, neo4j-dump, sqlite) — all of which need to open the same
+    duckdb. If the solr stage takes a write lock for this CREATE TABLE, every
+    other stage races on the file lock. Running this sequentially before the
+    fan-out lets every parallel reader use `read_only=True`.
+    """
+    database_path = Path(output_dir) / f"{name}.duckdb"
+    logger = get_logger()
+    logger.info(f"Materializing _solr_edges in {database_path}...")
+    conn = duckdb.connect(str(database_path))
+    try:
+        conn.execute(
+            """
+            CREATE OR REPLACE TABLE _solr_edges AS
+            SELECT *,
+                   CASE
+                     WHEN has_quotient IS NOT NULL THEN CAST(has_quotient AS DOUBLE)
+                     WHEN frequency_qualifier = 'HP:0040280' THEN 1.0
+                     WHEN frequency_qualifier = 'HP:0040281' THEN 0.8
+                     WHEN frequency_qualifier = 'HP:0040282' THEN 0.3
+                     WHEN frequency_qualifier = 'HP:0040283' THEN 0.05
+                     WHEN frequency_qualifier = 'HP:0040284' THEN 0.01
+                     WHEN frequency_qualifier = 'HP:0040285' THEN 0.0
+                     ELSE 0.0
+                   END AS frequency_computed_sortable_float
+            FROM denormalized_edges
+            """
+        )
+    finally:
+        conn.close()
+    logger.info("Materialized _solr_edges")
+
+
 #     sh.mv(database, f"{output_dir}/")
 
 

--- a/src/monarch_ingest/main.py
+++ b/src/monarch_ingest/main.py
@@ -273,6 +273,20 @@ def closure():
     apply_closure()
 
 
+@typer_app.command("prepare-solr")
+def prepare_solr_cmd():
+    """Materialize `_solr_edges` (denormalized_edges + frequency_computed_sortable_float).
+
+    Run sequentially after `merge`/`closure` and before the parallel post-merge
+    stages so the solr stage doesn't take a write lock on the duckdb while
+    other readers (kgx-graph-summary, kgx-transforms, neo4j-dump, sqlite,
+    connectivity) are running.
+    """
+    from monarch_ingest.cli_utils import prepare_solr
+
+    prepare_solr()
+
+
 @typer_app.command()
 def jsonl():
     from monarch_ingest.cli_utils import load_jsonl


### PR DESCRIPTION
## Problem

`parallel-processing` in the Jenkinsfile runs six stages concurrently — `kgx-graph-summary`, `connectivity-report`, `solr`, `kgx-transforms`, `neo4j-dump`, `sqlite` — that all open `output/monarch-kg.duckdb`. Today the solr stage's `scripts/load_solr.sh` runs:

```python
db = duckdb.connect('output/monarch-kg.duckdb')   # write mode
db.execute("CREATE OR REPLACE TABLE _solr_edges AS SELECT ..., frequency_computed_sortable_float ... FROM denormalized_edges")
```

This was introduced in 06a6c00 when `frequency_computed_sortable_float` moved out of a per-doc Nashorn JS update processor. The CREATE TABLE takes a write lock; while it's held, every other parallel stage crashes:

```
_duckdb.IOException: Could not set lock on file ".../monarch-kg.duckdb":
Conflicting lock is held in /usr/bin/python3.10 (PID 3336) by user jenkins.
```

## Fix

Split the materialization into its own explicit pipeline step, run sequentially before the fan-out:

- **`src/monarch_ingest/cli_utils.py::prepare_solr()`** — single-purpose function that does the `CREATE OR REPLACE TABLE _solr_edges` (same SQL, same row count, same HPO frequency mapping — `HP:0040280..HP:0040285`, default `0.0`).
- **`src/monarch_ingest/main.py`** — `ingest prepare-solr` typer command exposing it.
- **`Jenkinsfile`** — new `prepare-solr` stage between `neo4j-csv` and `parallel-processing`, so the table is in place before the fan-out starts.
- **`scripts/load_solr.sh`** — drops its inline materialization. Instead opens duckdb `read_only=True`, verifies `_solr_edges` exists, and fails loud with a pointer to `ingest prepare-solr` if not.

## Verification

Locally on this branch:

```
$ uv run python -c "import duckdb; con=duckdb.connect('output/monarch-kg.duckdb'); con.execute('DROP TABLE IF EXISTS _solr_edges')"
$ poetry run ingest prepare-solr
… Materializing _solr_edges in output/monarch-kg.duckdb...
… Materialized _solr_edges
$ # check table
_solr_edges: 15,118,831 rows
has frequency_computed_sortable_float: True
$ # load_solr.sh positive check
_solr_edges present.
$ # negative path
ERROR: _solr_edges not found - run "ingest prepare-solr" first.
$ # concurrent read_only opens (the scenario that was breaking)
  reader 0: 15,118,831 rows
  reader 1: 15,118,831 rows
  reader 2: 15,118,831 rows
all three read_only opens succeeded concurrently
```

No behavior change in the materialized data — same SQL, same column, same frequency mapping. The only change is *when* it happens (sequentially, ahead of the parallel block) and *who* owns it (an explicit CLI command and pipeline stage instead of an in-script side effect during solr indexing).