### PR TITLE
Phenio gene filter: dedupe ncbi_gene-covered taxa, bring in non-MOD/non-human species, drop empty-taxon stubs

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -210,6 +210,39 @@ def transform_phenio(
     excluded_nodes = nodes_df[nodes_df["id"].str.startswith(tuple(exclude_prefixes))]
     nodes_df = nodes_df[~nodes_df["id"].str.startswith(tuple(exclude_prefixes))]
 
+    # Drop phenio Gene nodes for taxa already covered by the per-species
+    # ncbi_gene ingest (its TSVs are the authoritative source). Other taxa
+    # phenio carries (cat, sheep, horse, rabbit, macaque, marmoset, hamster,
+    # goat, quail, medaka, etc.) have no other ingest, so we keep them.
+    ncbi_gene_covered_taxa = {
+        "NCBITaxon:9031",  # Gallus gallus (chicken)
+        "NCBITaxon:9615",  # Canis lupus familiaris (dog)
+        "NCBITaxon:9823",  # Sus scrofa (pig)
+        "NCBITaxon:9913",  # Bos taurus (cow)
+        "NCBITaxon:227321",  # Neurospora crassa
+    }
+    gene_mask = nodes_df["category"] == "biolink:Gene"
+    duplicate_gene_mask = gene_mask & nodes_df["in_taxon"].isin(ncbi_gene_covered_taxa)
+    if duplicate_gene_mask.any():
+        excluded_nodes = pandas.concat([excluded_nodes, nodes_df[duplicate_gene_mask]])
+        logger.info(
+            f"Removing {int(duplicate_gene_mask.sum())} phenio Gene nodes for taxa already covered by ncbi_gene"
+        )
+        nodes_df = nodes_df[~duplicate_gene_mask]
+
+    # Drop Gene-category rows with no in_taxon. They're a handful of orphan
+    # NCBIGene stubs (one is literally `NCBIGene:None`, the rest have empty
+    # name/description/xref) — without a taxon we can't responsibly include
+    # them under the cross-species expansion rationale.
+    gene_mask = nodes_df["category"] == "biolink:Gene"
+    empty_taxon_gene_mask = gene_mask & nodes_df["in_taxon"].fillna("").eq("")
+    if empty_taxon_gene_mask.any():
+        excluded_nodes = pandas.concat([excluded_nodes, nodes_df[empty_taxon_gene_mask]])
+        logger.info(
+            f"Removing {int(empty_taxon_gene_mask.sum())} phenio Gene nodes with empty in_taxon"
+        )
+        nodes_df = nodes_df[~empty_taxon_gene_mask]
+
     # Replace biolink:Occurrent category with biolink:BiologicalProcessOrActivity as a fallback to rescue
     # GO nodes that are getting a mixin category of Occurrent that we don't want to exclude all of
     nodes_df["category"] = nodes_df["category"].str.replace("biolink:Occurrent", "biolink:BiologicalProcessOrActivity")


### PR DESCRIPTION
## Why

`transform_phenio` filters Gene nodes by ID-prefix today (`HGNC`/`FlyBase` excluded explicitly, `MGI` excluded by a separate rule). That dropped any phenio gene whose canonical source was elsewhere in the ingest — but in the current data it had two side-effects:

1. **`NCBIGene` was never on the exclude list**, so phenio's per-species genes for chicken/dog/pig/cow — the taxa already covered by the per-species `ncbi_gene` ingest — flowed in alongside the canonical ones (**501 silently duplicated nodes**).
2. Conversely, ~268 phenio Gene nodes for **non-MOD, non-human species** (Felis catus, Ovis aries, Equus caballus, Oryctolagus cuniculus, Macaca mulatta/fascicularis, Callithrix jacchus, Mesocricetus auratus, Capra hircus, Coturnix japonica, Oryzias latipes, plus a long tail of singletons from gorilla, panda, ferret, marmoset, guinea pig, etc.) **have no other ingest**. Today they pass through because none of HGNC/FlyBase/MGI matched — but the mechanism is coincidental, not principled.

## What

Add a **taxon-based** filter step in `transform_phenio` alongside the existing prefix exclusions:

- Drop Gene-category rows whose `in_taxon` is in the set covered by `ncbi_gene` (`NCBITaxon:9031,9615,9823,9913,227321`). Removes the 501 duplicates and lets `ncbi_gene` own those species cleanly.
- Drop Gene-category rows with **empty `in_taxon`**. There are 16 of these in the current phenio release; one is literally `NCBIGene:None` and the rest have empty `name`/`description`/`xref` — pure stubs that can't be assigned to any species.

Everything else flows through unchanged:
- HGNC, FlyBase, MGI: still owned by the existing prefix filter.
- The +268 non-MOD species rows: explicitly preserved (the taxa covered by other ingests are enumerated; everything else passes).
- Edge filter: unchanged — out of scope (the existing edge prefix filter is about endpoint provenance, not the gene-source question this PR addresses).

## Verification

Local `ingest transform --phenio` + `ingest merge --closure`:

```
INFO  Removing 501 phenio Gene nodes for taxa already covered by ncbi_gene
INFO  Removing 16 phenio Gene nodes with empty in_taxon
…
Merge step took 156.73 seconds
Closure step took 88.19 seconds
validate_qc_counts returned error: False
```

Confirmed in the merged KG:

- ncbi_gene-covered taxa: **0 rows** sourced from `phenio_nodes` (chicken/dog/pig/cow).
- New species sourced from `phenio_nodes` (selected): Felis catus 89, Ovis aries 43, Equus caballus 38, Oryctolagus cuniculus 22, Macaca mulatta 14, Macaca fascicularis 10, plus marmoset/hamster/goat/quail/medaka/etc.
- HGNC from phenio: still 0.
- Yeast: still sourced cleanly from `alliance_gene_nodes` under `NCBITaxon:559292` (the strain) — no phenio overlap.
- No qc_expect regressions; the only warning is the pre-existing alliance_gene_to_expression shortfall, unrelated to this change.

## Out of scope

- Edge filter still uses prefix-based exclusion. Different concern (endpoint provenance, not source authority), worth a separate look.
- Alliance using strain-level `NCBITaxon:559292` rather than species-level `4932` for S. cerevisiae is a cross-referencing nuance worth knowing but not addressed here.