### PR TITLE
Keep phenio's HGNC-incident edges with original_predicate; drop only typing axioms

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -308,11 +308,32 @@ def transform_phenio(
         for field in ["subject", "object"]:
             edges_df[field] = edges_df[field].str.replace(f"OBO:{prefix}_", f"{prefix}:")
 
-    # Only keep edges where the subject and object both are within our allowable prefix list
+    # Edge-side prefix exclusions are narrower than node-side: HGNC edges
+    # need a finer carve-out (see below), so they're handled separately.
+    edge_exclude_prefixes = [p for p in exclude_prefixes if p != "HGNC"]
     edges_df = edges_df[
-        ~edges_df["subject"].str.startswith(tuple(exclude_prefixes))
-        & ~edges_df["object"].str.startswith(tuple(exclude_prefixes))
+        ~edges_df["subject"].str.startswith(tuple(edge_exclude_prefixes))
+        & ~edges_df["object"].str.startswith(tuple(edge_exclude_prefixes))
     ]
+
+    # HGNC-incident edges: drop the `biolink:subclass_of` typing-axiom
+    # shape (e.g. `HGNC:X subclass_of biolink:Gene`). That's pure clutter —
+    # gene typing already comes from hgnc_gene's `category` column. Keep
+    # the rest, crucially the ~6k disease→gene assertions whose
+    # `original_predicate` is RO:0004003 ("has material basis in germline
+    # mutation in") and a small RO:0004020 / RO:0004004 tail. They flatten
+    # to `biolink:related_to` in the biolink mapping but the specific RO
+    # term (preserved as original_predicate, see 0f0ee6e) is the signal —
+    # OMIM/Orphanet germline disease-gene calls aggregated by phenio.
+    hgnc_typing_mask = (
+        (edges_df["subject"].str.startswith("HGNC:") | edges_df["object"].str.startswith("HGNC:"))
+        & (edges_df["predicate"] == "biolink:subclass_of")
+    )
+    if hgnc_typing_mask.any():
+        logger.info(
+            f"Removing {int(hgnc_typing_mask.sum())} HGNC-incident biolink:subclass_of typing-axiom edges"
+        )
+        edges_df = edges_df[~hgnc_typing_mask]
 
     # Remove edges where the subject or object is NA
     edges_df = edges_df[~edges_df["subject"].isna() & ~edges_df["object"].isna()]


### PR DESCRIPTION
## Why

`transform_phenio` used a single `exclude_prefixes = ["HGNC", "FlyBase", "http", "biolink"]` list for both nodes and edges. On the edge side, applying that list to HGNC was dropping ~10.8k phenio edges in the current release — but the mix is mostly signal, not noise:

| n | predicate | original_predicate | what it is |
|---|---|---|---|
| **6,172** | `biolink:related_to` | `RO:0004003` | has material basis in germline mutation in |
| 19 | `biolink:related_to` | `RO:0004020` | |
| 10 | `biolink:causes` | `RO:0004001` | |
| 8 | `biolink:related_to` | `RO:0004004` | |
| 3 | `biolink:has_participant` | `RO:0004021` | |
| 1 | `biolink:disrupts` | `RO:0004025` | |
| 1 | `biolink:caused_by` | `RO:0004028` | |
| **6,214 kept** | | | **disease → HGNC-gene assertions from OMIM/Orphanet, aggregated by phenio** |
| 4,638 dropped | `biolink:subclass_of` | (typing) | `HGNC:X subclass_of biolink:Gene` clutter; typing already comes from `hgnc_gene.category` |

These flatten to `biolink:related_to` only because RO:0004003 etc. don't have 1:1 biolink slot mappings — the specific RO term, preserved as `original_predicate` (`0f0ee6e`), is the actual signal. Dropping them along with the typing axioms erased OMIM/Orphanet germline disease-gene calls phenio uniquely aggregates.

## What

Split node-side and edge-side exclusion in `transform_phenio`:

- **Nodes**: `exclude_prefixes` unchanged — HGNC nodes still owned by `hgnc_gene`, dropped from phenio as before.
- **Edges**: `edge_exclude_prefixes = exclude_prefixes - {"HGNC"}`. Then add one targeted mask that drops HGNC-incident `biolink:subclass_of` edges — the typing-axiom clutter that has no biological signal.

Concretely:

```python
edge_exclude_prefixes = [p for p in exclude_prefixes if p != "HGNC"]
edges_df = edges_df[
    ~edges_df["subject"].str.startswith(tuple(edge_exclude_prefixes))
    & ~edges_df["object"].str.startswith(tuple(edge_exclude_prefixes))
]

hgnc_typing_mask = (
    (edges_df["subject"].str.startswith("HGNC:") | edges_df["object"].str.startswith("HGNC:"))
    & (edges_df["predicate"] == "biolink:subclass_of")
)
edges_df = edges_df[~hgnc_typing_mask]
```

## Verification

`ingest transform --phenio` against the latest kg-phenio release:

```
INFO  Removing 501 phenio Gene nodes for taxa already covered by ncbi_gene
INFO  Removing 16 phenio Gene nodes with empty in_taxon
INFO  Removing 4638 HGNC-incident biolink:subclass_of typing-axiom edges
```

Post-transform inspection of `output/transform_output/phenio_edges.tsv`:

```
HGNC-incident edges by (predicate | original_predicate):
  6172  biolink:related_to       | RO:0004003
    19  biolink:related_to       | RO:0004020
    10  biolink:causes           | RO:0004001
     8  biolink:related_to       | RO:0004004
     3  biolink:has_participant  | RO:0004021
     1  biolink:disrupts         | RO:0004025
     1  biolink:caused_by        | RO:0004028

HGNC-incident biolink:subclass_of remaining: 0
```

## Net effect

- **+6,214 phenio edges** flow in — all with specific RO `original_predicate` provenance; ~99% are disease→gene germline mutation calls (`RO:0004003`).
- **−4,638 typing-axiom edges** out.
- Node behavior unchanged (HGNC nodes still owned by `hgnc_gene`).
- FlyBase / http / biolink edge filtering unchanged (the latter two never matched anything in this release; FlyBase 0 too).

## Out of scope

- The wider edge-filter cleanup (FlyBase / http / biolink entries hit 0 today and are arguably dead code; principled "source-authority by predicate" filter parallel to the node taxon rule) — defer until someone has a concrete use case for it.