### PR TITLE
load_solr.sh: verify core doc counts after load

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "kghub-downloader>=0.4.5,<1",
     "kgx>=2.6.0,<3",
     "linkml>=1.9,<2", #TODO: upgrade this to 1.11 when biolink-model makes that upgrade. https://github.com/biolink/biolink-model/issues/1726
-    "linkml-solr==0.2.0",
+    "linkml-solr==0.2.3",
     "multi-indexer==0.0.5",
     # Other Dependencies,
     "botocore>=1.31,<2",

--- a/scripts/load_solr.sh
+++ b/scripts/load_solr.sh
@@ -137,6 +137,46 @@ for core in entity association sssom infores; do
     -H "Content-type: text/xml" --data-binary '' >/dev/null || true
 done
 
+# Post-load verification (defense in depth). The bulk loader now fails loud on
+# dropped chunks, but a silently short index is the single worst release defect
+# we can ship — build #328 published a half-empty entity core that still passed
+# as SUCCESS. So independently assert each big core's committed numDocs equals
+# the count of distinct ids in its source table, and abort the release if not.
+echo "Verifying Solr core doc counts against source tables..."
+uv run python - <<'PYEOF'
+import sys
+import duckdb
+import requests
+
+DB = "output/monarch-kg.duckdb"
+# core -> source table feeding it (Solr dedupes by id, so the expected number of
+# indexed docs is the count of DISTINCT ids in the source).
+CHECKS = {
+    "entity": "denormalized_nodes",
+    "association": "_solr_edges",
+}
+
+con = duckdb.connect(DB, read_only=True)
+failures = []
+for core, table in CHECKS.items():
+    expected = con.execute(f"SELECT count(DISTINCT id) FROM {table}").fetchone()[0]
+    resp = requests.get(
+        f"http://localhost:8983/solr/{core}/select",
+        params={"q": "*:*", "rows": 0},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    got = resp.json()["response"]["numFound"]
+    status = "OK" if got == expected else "MISMATCH"
+    print(f"  {core}: numDocs={got:,} expected={expected:,} ({status})")
+    if got != expected:
+        failures.append(f"{core}: {got} indexed != {expected} expected ({table})")
+
+if failures:
+    sys.exit("ERROR: Solr load incomplete:\n  - " + "\n  - ".join(failures))
+print("All core doc counts match source tables.")
+PYEOF
+
 # The tarball is the release artifact Jenkins publishes; for local runs we
 # usually just want the live container to query against, and producing the
 # ~30 GB tar adds minutes for no benefit. Set SOLR_SKIP_TARBALL=1 to skip

--- a/uv.lock
+++ b/uv.lock
@@ -2396,7 +2396,7 @@ wheels = [
 
 [[package]]
 name = "linkml-solr"
-version = "0.2.0"
+version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "duckdb" },
@@ -2407,9 +2407,9 @@ dependencies = [
     { name = "pysolr" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/fe/62199369b4a6a75d3366f438c326357dd77119fa7e0a7d6cd5aa94d5377e/linkml_solr-0.2.0.tar.gz", hash = "sha256:7953d23ae572d80f19debee0242d092add43163304bfba5d6864f214be0ae819", size = 16676, upload-time = "2025-09-11T18:30:39.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/21/0d34262581a48a637ddda70a523b9fbfb3cf14044d4764ee9511489cc8ce/linkml_solr-0.2.3.tar.gz", hash = "sha256:5de9a3ff2c6f6fc466293e61d87ef72bdd4097b0fceee2e4b6958effc4c209cc", size = 18008, upload-time = "2026-06-09T15:24:52.790942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/77/54f39b4137c60e4a8a4218fe551f02c680d9e5b4422d86f3a0ba782cc1e6/linkml_solr-0.2.0-py3-none-any.whl", hash = "sha256:9418b1b598cb3762ceba41394f365c8f8a3367b6dc2c59d24c89938dd32dd82c", size = 20744, upload-time = "2025-09-11T18:30:38.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/716105c0bc0615e1d31f084c34c0cf52b7af50f1061a8d2569353e862111/linkml_solr-0.2.3-py3-none-any.whl", hash = "sha256:e921d758dd30dd7e1cdf2b327f4a6dff21738ff253174fa6166d7d2df6dc29eb", size = 22086, upload-time = "2026-06-09T15:24:51.860349Z" },
 ]
 
 [[package]]
@@ -2692,7 +2692,7 @@ requires-dist = [
     { name = "koza", extras = ["grape"], specifier = ">=2.5,<3" },
     { name = "linkml", specifier = ">=1.9,<2" },
     { name = "linkml-runtime", specifier = ">=1.7.5,<2" },
-    { name = "linkml-solr", specifier = "==0.2.0" },
+    { name = "linkml-solr", specifier = "==0.2.3" },
     { name = "loguru" },
     { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.4,<2" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5" },


### PR DESCRIPTION
## Problem

The Solr release build can ship a **silently incomplete** index. In build #328 (the 2026-06-08 dev release), the `lsolr bulkload-db` step dropped ~half its chunks to upload timeouts, swallowed the errors, and exited `0` — so the `entity` core was published with ~728k of ~1.46M docs (association similarly short) while the Jenkins job passed as **SUCCESS**. Downstream, `get_entity()` returned `None` for genes/diseases that existed in the same release's graph, breaking semsim search / fixture generation.

The graph itself was fine — `denormalized_nodes` had the full 1,462,594 rows and the missing genes. Only the Solr load was short, and nothing checked.

## Fix

After the per-core commit loop, independently verify each big core's committed `numDocs` against its source table and **exit non-zero on mismatch**:

- `entity` ↔ `count(distinct id)` of `denormalized_nodes`
- `association` ↔ `count(distinct id)` of `_solr_edges`

This is defense in depth at the pipeline level. The underlying loader is being fixed to fail loud on dropped chunks (linkml/linkml-solr#24); this check guarantees that even a future regression can't tar and publish a short core — the build aborts before the tarball step.

## Validation

Ran the full load against the 2026-06-08 duckdb with the patched linkml-solr:
```
entity: numDocs=1,462,594 expected=1,462,594 (OK)
association: numDocs=15,211,571 expected=15,211,571 (OK)
All core doc counts match source tables.
```

## Notes

- Pairs with linkml/linkml-solr#24 (retry + fail-loud in the loader). This PR is the independent pipeline-level guardrail.
- `_solr_edges` is already a precondition of this stage (materialized by `ingest prepare-solr`), so the association count is available without extra work.