### PR TITLE
Fix Content-Type on *.tsv.gz release uploads

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -1215,6 +1215,15 @@ def do_release(dir: str = OUTPUT_DIR, kghub: bool = False):
         # copy to monarch-archive bucket
         sh.gsutil(*f"-q -m cp -r {dir}/* gs://monarch-archive/monarch-kg-dev/{release_ver}".split(" "))
 
+        # gsutil auto-detects *.tsv.gz as text/tab-separated-values (from the .tsv part),
+        # which makes browsers render the gzip inline instead of downloading it. Set the
+        # correct type here; all downstream GCS->GCS copies inherit it.
+        sh.gsutil(
+            *"-q -m setmeta -h".split(" "),
+            "Content-Type:application/gzip",
+            f"gs://monarch-archive/monarch-kg-dev/{release_ver}/tsv/**/*.tsv.gz",
+        )
+
         # copy to data-public bucket
         sh.gsutil(
             *"-q -m cp -r".split(" "),


### PR DESCRIPTION
## Summary

Release uploads set `Content-Type: text/tab-separated-values` on the `tsv/**/*.tsv.gz` dumps, because `gsutil cp` auto-detects the type from the `.tsv` part of the name. Since that's a `text/*` type (and there's no `Content-Disposition`), browsers render the binary gzip **inline** instead of downloading it — the file looks empty/garbage.

Reported via the help desk for the "Disease or phenotypic feature to genetic inheritance association" download (monarch-initiative/monarch-app#1322). The data is fine (9,070 rows); only the HTTP content-type is wrong.

## Fix

Set `Content-Type: application/gzip` on `tsv/**/*.tsv.gz` immediately after the first GCS upload in `do_release()`. Everything after that (the data-public dev copy, the `latest` copy, and the eventual dev→prod promotion) is a GCS→GCS metadata-preserving copy, so the corrected type propagates automatically.

```python
sh.gsutil(
    *"-q -m setmeta -h".split(" "),
    "Content-Type:application/gzip",
    f"gs://monarch-archive/monarch-kg-dev/{release_ver}/tsv/**/*.tsv.gz",
)
```

The `.tar.gz` / `.db.gz` / `.nt.gz` artifacts are unaffected — they already get download-friendly `application/*` types.

## Live objects already patched

The existing releases were patched manually with `gsutil setmeta` (`latest` + 3 recent dated dirs in both `monarch-kg` and `monarch-kg-dev`); the CDN (`max-age=3600`) refreshes within ~1h. This PR prevents the next release from reintroducing the bug.

Fixes #695