### PR TITLE
Include kozahub loinc-ingest in the KG build

### DIFF
--- a/src/monarch_ingest/ingests.yaml
+++ b/src/monarch_ingest/ingests.yaml
@@ -206,6 +206,35 @@ cureid:
     - cureid_nodes.tsv
     - cureid_edges.tsv
 
+# LOINC clinical measurements (kozahub loinc-ingest, alpha). One repo, five
+# transforms: two node sets (leaf measurement codes + backbone "part" nodes) and
+# three edge sets (compositional related_to, is_a hierarchy, outcome-typed
+# phenotype correlated_with).
+loinc_nodes:
+  repo: loinc-ingest
+  files:
+    - loinc_nodes_nodes.tsv
+
+loinc_parts:
+  repo: loinc-ingest
+  files:
+    - loinc_parts_nodes.tsv
+
+loinc_composition:
+  repo: loinc-ingest
+  files:
+    - loinc_composition_edges.tsv
+
+loinc_hierarchy:
+  repo: loinc-ingest
+  files:
+    - loinc_hierarchy_edges.tsv
+
+loinc_phenotype:
+  repo: loinc-ingest
+  files:
+    - loinc_phenotype_edges.tsv
+
 # kg-phenio is consumed via download.yaml (kg-phenio.tar.gz), not via the
 # kozahub artifact pattern, so this is a metadata-only entry: it contributes
 # its release-metadata.yaml to the build receipt but has no transform.

--- a/src/monarch_ingest/qc_expect.yaml
+++ b/src/monarch_ingest/qc_expect.yaml
@@ -40,6 +40,10 @@ nodes:
       min: 60000
     cureid_nodes:
       min: 10
+    loinc_nodes_nodes:
+      min: 100000
+    loinc_parts_nodes:
+      min: 3000
 edges:
   provided_by:
     alliance_gene_to_expression_edges:
@@ -111,4 +115,10 @@ edges:
       min: 7000
     cureid_edges:
       min: 200
+    loinc_hierarchy_edges:
+      min: 24000
+    loinc_composition_edges:
+      min: 13000
+    loinc_phenotype_edges:
+      min: 10000
 


### PR DESCRIPTION
## Summary

Registers the new kozahub **`loinc-ingest`** (LOINC clinical measurements as a Biolink/KGX subgraph) in `ingests.yaml`, so its KGX artifacts are pulled from the GitHub release and merged into monarch-kg, and its `release-metadata.yaml` lands in the build receipt. Adds `qc_expect.yaml` mins from a local full-KG build.

One repo, five transforms / outputs (filenames verified against the published release assets):

| entry | file | produced | survives merge |
|---|---|---:|---:|
| `loinc_nodes` | `loinc_nodes_nodes.tsv` | 104,672 nodes | 104,672 (100%) |
| `loinc_parts` | `loinc_parts_nodes.tsv` | 3,119 nodes | 3,119 (100%) |
| `loinc_hierarchy` | `loinc_hierarchy_edges.tsv` | 24,310 edges (is_a) | 24,310 (100%) |
| `loinc_phenotype` | `loinc_phenotype_edges.tsv` | 10,946 edges (`correlated_with`, LOINC↔HP) | 10,946 (100%) |
| `loinc_composition` | `loinc_composition_edges.tsv` | 15,444 edges (`related_to`) | 13,817 (89.5%) |

## Validation — local full-KG build

Built the full monarch-kg locally on this branch (1,570,385 nodes / 15,256,860 edges). loinc post-normalization/prune survival is shown above: nodes, hierarchy, and the Monarch-relevant phenotype edges survive 100%. The only dangling is ~10.5% of composition edges, pointing at **NCBITaxon / CHEBI / PR** targets that monarch-kg doesn't carry as nodes (expected). `qc_report.yaml` includes all five loinc entries, and `validate_qc_counts` passes against the added mins.

`qc_expect.yaml` mins (≈ current surviving counts; the validator's 0.7 factor gives headroom):
- nodes: `loinc_nodes_nodes` 100000 · `loinc_parts_nodes` 3000
- edges: `loinc_hierarchy_edges` 24000 · `loinc_composition_edges` 13000 · `loinc_phenotype_edges` 10000

Release `2026-06-27` is published; all five `releases/latest/download/` URLs resolve. All 67 monarch-ingest tests pass.

https://claude.ai/code/session_01SMhNpLnWjUztXLtB5pdjPp