### PR TITLE
merge: force category single-valued (restore scalar convention)

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -570,6 +570,12 @@ def _merge_files_koza(
         output_format=KGXFormat.TSV,
         # Require primary_knowledge_source on all edges (issue #1276)
         required_edge_fields=["primary_knowledge_source"],
+        # Collapse `category` to a single value on both nodes and edges. koza >=2.6
+        # preserves Biolink-multivalued slots (category is multivalued), which would
+        # flip monarch-kg's `category` from scalar to a list — but the API model
+        # (Association/Node `category: str`), Solr, and the similarity engine all
+        # expect a single string. Keep the historical scalar convention.
+        force_single_valued=["category"],
     )
 
     result = merge_graphs(config)


### PR DESCRIPTION
## Problem

koza ≥2.6 preserves Biolink-multivalued slots, so `category` now flows through the merge as a list (`VARCHAR[]`). On the next build that silently flips monarch-kg's `category` from a scalar string to an array — diverging from what's deployed and what every downstream consumer expects:

- **API**: `api.monarchinitiative.org/v3/api/association` currently returns scalar `category` (a plain string), and the monarch-app model declares `category: Optional[str]` on both `Association` and `Node`.
- **Solr** indexes `category` as a single value.
- The in-process **similarity engine** and koza's **information-content** op filter associations with scalar `category IN (...)`.

Caught by a local full-KG build on koza 2.6: `nodes.category` / `edges.category` came out `VARCHAR[]`, and the `information-content` step crashed building `closure_size` (`Type VARCHAR ... can't be cast to VARCHAR[]`).

## Fix

Pass `force_single_valued=["category"]` to the merge config. koza applies it to both the node-load and edge-load paths, collapsing `category` to a single value everywhere — restoring the historical scalar convention.

## Verification

Local full build with the fix:
- `nodes.category` → `VARCHAR`, `edges.category` → `VARCHAR` (no longer `[]`).
- Scalar `category IN (...)` filters work again (1,095,109 has_phenotype Gene/Disease assocs).
- All 67 tests pass.

## Related

- koza #235 makes the `information-content` op array-aware as defense-in-depth, but with this change `category` stays scalar so it isn't required for monarch-kg.
- A deliberate future move to multivalued `category` would be a coordinated change across the API model, Solr, frontend, IC, and the engine — explicitly out of scope here.

https://claude.ai/code/session_01SMhNpLnWjUztXLtB5pdjPp