### PR TITLE
merge: also force in_taxon and type single-valued

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -570,12 +570,15 @@ def _merge_files_koza(
         output_format=KGXFormat.TSV,
         # Require primary_knowledge_source on all edges (issue #1276)
         required_edge_fields=["primary_knowledge_source"],
-        # Collapse `category` to a single value on both nodes and edges. koza >=2.6
-        # preserves Biolink-multivalued slots (category is multivalued), which would
-        # flip monarch-kg's `category` from scalar to a list — but the API model
-        # (Association/Node `category: str`), Solr, and the similarity engine all
-        # expect a single string. Keep the historical scalar convention.
-        force_single_valued=["category"],
+        # Collapse to a single value on both nodes and edges. koza >=2.6 preserves
+        # Biolink-multivalued slots, which flips several slots monarch treats as
+        # scalar from a string to a list. category, in_taxon, and type are
+        # `Optional[str]` in the monarch-app model (and Solr / the QC report SQL /
+        # the similarity engine all assume scalar) — keep the historical scalar
+        # convention for exactly those. Everything genuinely multivalued (xref,
+        # synonym, publications, has_evidence, aggregator_knowledge_source, ...)
+        # stays a list.
+        force_single_valued=["category", "in_taxon", "type"],
     )
 
     result = merge_graphs(config)


### PR DESCRIPTION
## Problem

Follow-up to #699 (which forced `category` single-valued). koza ≥2.6 preserves Biolink-multivalued slots, which flips **`in_taxon`** and **`type`** from scalar to lists too. A dev KG build (`monarch-ingest-all` #329, on main) **failed in the `report` (QC) stage**:

```
ingest report → con.execute(scripts/generate_reports.sql)
ConversionException: Type VARCHAR with value 'NCBITaxon:9606' can't be cast to the destination type VARCHAR[]
```

The QC SQL does scalar `in_taxon = 'NCBITaxon:9606'` and `group by in_taxon`, which throws on an array column.

## Why these three slots

In the monarch-app model, exactly `category`, `in_taxon`, and `type` are `Optional[str]` (scalar); everything else that koza arrays (xref, synonym, publications, has_evidence, aggregator_knowledge_source, qualifiers, *_synonym, subsets, has_gene, same_as, …) is genuinely `list`. So only those three need forcing.

## Fix

`force_single_valued=["category", "in_taxon", "type"]`.

## Verification

Clean local rebuild (merge → closure → **report** → information-content):
- `nodes.category` / `in_taxon` / `type` are all `VARCHAR` (scalar).
- The **QC report runs without error** (`qc_report.yaml` written).
- **information-content** builds: `information_content` 418,127 terms, `closure_size` 51,581 entities.
- 67 tests pass.

This unblocks the dev KG build (the `report` stage was failing before information-content even ran).

https://claude.ai/code/session_01SMhNpLnWjUztXLtB5pdjPp