### PR TITLE
neo4j-csv: derive column types from DuckDB, not the LinkML model

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -1028,16 +1028,26 @@ def get_neo4j_column(field: str) -> str:
 def get_neo4j_column_from_db(field: str, column_types: dict) -> str:
     """
     Convert a field name to a column specification with Neo4j type annotations.
-    Uses actual database column types to determine if a field is multi-valued.
-    """
-    col_type = column_types.get(field, "VARCHAR")
-    is_array = col_type.endswith("[]")
 
-    if slot_is_integer(field):
+    Derives the Neo4j type entirely from the actual DuckDB column type. This is
+    self-contained — it does not consult the LinkML schema — so neo4j export
+    works on whatever the merge produced and doesn't depend on a downloadable
+    monarch model schema being resolvable (see get_monarch_schema /
+    ensure_model_files, which couldn't resolve `monarch_kg_schema.yaml`).
+    """
+    col_type = column_types.get(field, "VARCHAR").upper()
+    is_array = col_type.endswith("[]")
+    base = col_type[:-2] if is_array else col_type
+
+    integer_types = {"BIGINT", "INTEGER", "HUGEINT", "SMALLINT", "TINYINT",
+                     "UBIGINT", "UINTEGER", "USMALLINT", "UTINYINT"}
+    float_types = {"DOUBLE", "FLOAT", "REAL", "DECIMAL"}
+
+    if base in integer_types:
         return f'{field} as "{field}:long"'
-    if slot_is_float(field):
+    if base in float_types or base.startswith("DECIMAL"):
         return f'{field} as "{field}:float"'
-    if slot_is_boolean(field):
+    if base == "BOOLEAN":
         return f'{field} as "{field}:boolean"'
     if is_array:
         return f"""array_to_string({field}, ';') as "{field}:string[]" """


### PR DESCRIPTION
## Problem

A dev KG build failed in the **`neo4j-csv`** stage:

```
ingest neo4j-csv → load_neo4j_csv → get_neo4j_column_from_db
  → slot_is_integer/float/boolean → get_monarch_schema() → ensure_model_files()
FileNotFoundError: .../monarch_kg_schema.yaml
```

`get_monarch_schema()` loads `model.yaml`, which imports `monarch_kg_schema` — not resolvable in the build workspace — so the whole build dies before `prepare-solr` / `information-content`.

## Fix

`get_neo4j_column_from_db` already receives the actual DuckDB column types, so derive the Neo4j type annotation straight from them and drop the LinkML schema lookup:

- `BIGINT`/`INTEGER`/… → `:long`
- `DOUBLE`/`FLOAT`/`DECIMAL` → `:float`
- `BOOLEAN` → `:boolean`
- `VARCHAR[]` → `:string[]` (`array_to_string`)
- else → string

This completes the "use actual DB column types" intent and removes the fragile dependency on a downloadable model schema.

## Verification

`ingest neo4j-csv` runs locally and produces the nodes/edges Neo4j CSVs — `evidence_count:long`, array columns as `:string[]` — with no schema error. 67 tests pass.

## Follow-up

This is a quick unblock. neo4j-csv export (KGX → Neo4j import CSV, with array/closure-aware column typing) really belongs in koza's graph-operations toolkit alongside the other exporters — tracked in a koza issue (linked separately).

https://claude.ai/code/session_01SMhNpLnWjUztXLtB5pdjPp