### PR TITLE
solr: source SSSOM core schema from sssom-schema package (stop downloading from monarch-app)

### DIFF
--- a/scripts/load_solr.sh
+++ b/scripts/load_solr.sh
@@ -14,11 +14,16 @@ if test -f "output/monarch-kg-denormalized-nodes.tsv.gz"; then
     gunzip --force output/monarch-kg-denormalized-nodes.tsv.gz
 fi
 
-echo "Download the schema files using pystow"
-# monarch-app's model.yaml is still used for the Mapping (sssom) core, but
-# the Entity and Association core schemas now come from the koza-produced
-# monarch-kg-schema.yaml that closurize emits alongside output/monarch-kg.duckdb.
-python -c "from monarch_ingest.cli_utils import ensure_model_files; ensure_model_files()"
+# No schema is downloaded from monarch-app anymore. All core schemas come from
+# the ingest side:
+#   - entity / association : the koza-produced output/monarch-kg-schema.yaml
+#     (closurize emits it alongside output/monarch-kg.duckdb)
+#   - sssom (Mapping)      : the canonical SSSOM schema shipped by the installed
+#     sssom-schema package (the mappings ARE SSSOM, unrelated to the KG schema)
+#   - infores             : data/infores/information_resource_registry.yaml
+echo "Resolving the SSSOM schema from the installed sssom-schema package"
+SSSOM_SCHEMA=$(uv run python -c "import sssom_schema, pathlib; print(pathlib.Path(sssom_schema.__file__).parent / 'schema' / 'sssom_schema.yaml')")
+echo "SSSOM schema: $SSSOM_SCHEMA"
 
 if ! test -f "output/monarch-kg-schema.yaml"; then
     echo "ERROR: output/monarch-kg-schema.yaml not found. Run \`ingest merge\` + \`ingest closure\` first."
@@ -81,7 +86,7 @@ for core_name in "${core_names[@]}"; do
 done
 
 echo "Adding sssom schema"
-uv run lsolr create-schema -C sssom -s model.yaml -t Mapping
+uv run lsolr create-schema -C sssom -s "$SSSOM_SCHEMA" -t mapping
 sleep 5
 
 echo "Adding infores schema"
@@ -101,7 +106,7 @@ curl -X POST -H 'Content-Type: application/json' \
   --data-binary @data/infores/infores_catalog.jsonl
 
 
-uv run lsolr bulkload-db -C sssom -s model.yaml output/monarch-kg.duckdb mappings
+uv run lsolr bulkload-db -C sssom -s "$SSSOM_SCHEMA" output/monarch-kg.duckdb mappings
 
 # `_solr_edges` (denormalized_edges + frequency_computed_sortable_float) is
 # materialized by `ingest prepare-solr`, run sequentially before this stage,


### PR DESCRIPTION
## Problem

The Solr stage was the last place still pulling a schema from monarch-app. `load_solr.sh` ran `ensure_model_files()` and used monarch-app's `model.yaml` for the **sssom (`Mapping`) core**:

```
lsolr create-schema -C sssom -s model.yaml -t Mapping
lsolr bulkload-db  -C sssom -s model.yaml output/monarch-kg.duckdb mappings
```

Since monarch-app `d3ff25ef "Invert KG-schema dependency: import koza-produced schema"`, `model.yaml` imports `monarch_kg_schema`, and both define `provided_by` — so loading it raises:

```
ValueError: Conflicting URIs (.../koza/graph-schema, .../monarch/monarch-py) for item: provided_by
```

→ `lsolr create-schema -s model.yaml` fails, sssom/association never load.

## Fix

Stop downloading from monarch-app. Source every core schema from the ingest side:

| core | schema |
|---|---|
| entity / association | koza-produced `output/monarch-kg-schema.yaml` (already) |
| **sssom (Mapping)** | the canonical SSSOM schema from the installed **`sssom-schema`** package (`mapping` class) — the mappings *are* SSSOM, unrelated to the KG schema |
| infores | `data/infores/information_resource_registry.yaml` (already) |

Drops the `ensure_model_files()` call from `load_solr.sh`.

## Verification

Ran `ingest solr` locally with this change: the **sssom core builds and loads** from the package schema and the **entity core loads** — zero monarch-app downloads, no `provided_by` conflict. The full 15 M-doc association load didn't finish *locally* only because the dev box ran out of disk (97% full) — a resource limit, not a code issue; it'll complete on Jenkins.

## Related
- #701 (neo4j-csv: derive column types from DuckDB) removes the other monarch-app `model.yaml` dependency. With both merged, no pipeline stage downloads schema from monarch-app. (`ensure_model_files`/`get_monarch_schema` become dead code — follow-up cleanup.)

https://claude.ai/code/session_01SMhNpLnWjUztXLtB5pdjPp