### PR TITLE
Include monarch-kg-schema.yaml in GitHub release assets

### DIFF
--- a/scripts/create_github_release.py
+++ b/scripts/create_github_release.py
@@ -8,6 +8,7 @@ DIR = Path(__file__).parent.parent / "output"
 GH_TOKEN = os.environ["GH_RELEASE_TOKEN"]
 UPLOAD_FILES = [
     "monarch-kg.tar.gz",
+    "monarch-kg-schema.yaml",
     "merged_graph_stats.yaml",
     "qc_report.yaml",
     "metadata.yaml",


### PR DESCRIPTION
## What

Adds `monarch-kg-schema.yaml` to the `UPLOAD_FILES` list in `scripts/create_github_release.py`.

## Why

The LinkML schema artifact is generated by `apply_closure` (via koza's `export_schema`) and written to `output/monarch-kg-schema.yaml`, but it was missing from the list of assets uploaded to the GitHub release by `create_github_release.py` (the script Jenkins runs). As a result the schema was published to the GCS buckets but never appeared as a GitHub release asset.

https://claude.ai/code/session_01DEQqLQkT9w4TkDQU76yu7r