### PR TITLE
Serve release .yaml files as text/plain so they're viewable in-browser

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -1292,6 +1292,15 @@ def do_release(dir: str = OUTPUT_DIR, kghub: bool = False):
             f"gs://monarch-archive/monarch-kg-dev/{release_ver}/tsv/**/*.tsv.gz",
         )
 
+        # gsutil serves *.yaml as application/octet-stream, which makes browsers
+        # download them instead of rendering. Serve as text/plain so they're
+        # viewable inline; all downstream GCS->GCS copies inherit it.
+        sh.gsutil(
+            *"-q -m setmeta -h".split(" "),
+            "Content-Type:text/plain; charset=utf-8",
+            f"gs://monarch-archive/monarch-kg-dev/{release_ver}/*.yaml",
+        )
+
         # copy to data-public bucket
         sh.gsutil(
             *"-q -m cp -r".split(" "),


### PR DESCRIPTION
## What

In `do_release`, set the GCS `Content-Type` on the release directory's `*.yaml` files to `text/plain; charset=utf-8`.

## Why

gsutil serves `*.yaml` objects as `application/octet-stream`, so opening one in a browser triggers a download instead of rendering it inline — annoying when you just want to glance at `metadata.yaml`, `qc_report.yaml`, `monarch-kg-schema.yaml`, etc.

This mirrors the existing fix for `*.tsv.gz` (`Content-Type:application/gzip`): the `setmeta` runs on the `monarch-archive/monarch-kg-dev/<version>` copy before the GCS→GCS copies to the public bucket and `latest`, so all downstream copies inherit the corrected type.

All YAML files written during a release land at the top level of the output dir (`metadata.yaml`, `qc_report.yaml`, `merged_graph_stats.yaml`, `connectivity_summary.yaml`, `*_schema_report.yaml`, `monarch-kg-schema.yaml`), so the top-level `*.yaml` glob covers them.

https://claude.ai/code/session_01DEQqLQkT9w4TkDQU76yu7r