### PR TITLE
Fix pandas 3 Copy-on-Write chained-assignment no-op in Phenio transform

### DIFF
--- a/src/monarch_ingest/cli_utils.py
+++ b/src/monarch_ingest/cli_utils.py
@@ -321,7 +321,7 @@ def transform_phenio(
     edges_df = edges_df[edges_df["predicate"].str.contains(":")]
 
     # assign level association category if edge category is empty
-    edges_df["category"].fillna("biolink:Association", inplace=True)
+    edges_df["category"] = edges_df["category"].fillna("biolink:Association")
 
     # Match the node-side FBBT/WBBT -> FBbt/WBbt case normalization so
     # phenio's internal anatomy-anatomy edges (subClassOf, part_of, etc.)


### PR DESCRIPTION
## Summary
- `pyproject.toml` pins `pandas>=2.0.3` with no upper bound, so a fresh lock now resolves pandas 3.0.2 (released 2026-03-31), which made Copy-on-Write mandatory.
- Under CoW, `edges_df["category"].fillna("biolink:Association", inplace=True)` in `transform_phenio` silently stops mutating the DataFrame — it only emits a `ChainedAssignmentError` warning (seen in the recent Jenkins `monarch-ingest-all` build log) and leaves the original `NaN` categories in place.
- Those `NaN`-category Phenio edges then get caught by the invalid-edge-category cleanup a few lines later and are **dropped entirely**, instead of being retained with the intended default category of `biolink:Association`.
- Fix: reassign instead of chained inplace — `edges_df["category"] = edges_df["category"].fillna("biolink:Association")` — which works correctly under CoW.
- Grepped the rest of `src/` for the same `df[col].method(..., inplace=True)` chained-assignment pattern; this was the only occurrence.

## Test plan
- [x] Reproduced the exact warning locally against pandas 3.0.2 with a minimal DataFrame, confirmed the original line left `NaN` in place and the fixed line correctly fills it.
- [ ] Run `transform_phenio` against real Phenio data (e.g. next Jenkins build or local `ingest transform phenio`) to confirm no more `ChainedAssignmentError` warning and that edges with missing category are retained with `biolink:Association` instead of being dropped.

https://claude.ai/code/session_01PZWfdbUpGK7fxVc5EESUzq