### PR TITLE
Drop term vectors from text type (store offsets in postings)

### DIFF
--- a/scripts/text-fieldtype.json
+++ b/scripts/text-fieldtype.json
@@ -3,9 +3,7 @@
     "name": "text",
     "class": "solr.TextField",
     "positionIncrementGap": "100",
-    "termVectors": "true",
-    "termOffsets": "true",
-    "termPositions": "true",
+    "storeOffsetsWithPositions": "true",
     "indexAnalyzer": {
       "tokenizer": {
         "class": "solr.StandardTokenizerFactory"


### PR DESCRIPTION
## What

On the shared `text` field type (`scripts/text-fieldtype.json`), replace `termVectors`/`termOffsets`/`termPositions=true` with `storeOffsetsWithPositions=true`. Applies to the `_t` fields on **both** the entity and association cores.

## Why (index-size win)

Term vectors are a bulky per-document data structure. On text-heavy multivalued fields — notably the association `*_closure_label_t` fields (~617M label occurrences) — they roughly **double** the on-disk footprint and add per-doc indexing/merge cost.

Measured on a local benchmark (30k real association docs, identical data, real analyzer):

| core | total index | term-vector files (`.tvd/.tvx/.tvm`) |
|---|---|---|
| term vectors (current) | 15.42 MB | 7.8 MB |
| `storeOffsetsWithPositions` (this PR) | 9.65 MB | 0 |

Term vectors were ~half the text-field index; dropping them nets **~37% smaller cores**, with `storeOffsetsWithPositions` adding only a small amount to the postings. This is an engine-level win for **any** Solr build (GCP today, HPC later): smaller index, faster indexing, less merge back-pressure.

## Highlighting still works — this is a storage change, not a correctness interlock

⚠️ **Correction to the earlier framing:** this PR does **not** degrade highlighting on its own, and it is **not** a hard correctness dependency with the monarch-app change. Verified empirically against a `storeOffsetsWithPositions` index (30k real docs; production `_t` is a `stored:true` dynamic field; production `/select` uses the default 'original' highlighter with no FastVectorHighlighter config):

- **Default 'original' highlighter still returns correct snippets without term vectors** — for plain *and* wildcard queries. Because the `_t` fields are `stored`, it re-analyzes the stored text. Term vectors were **not** being read by it at all (same highlight latency with or without them: 34 ms vs 31 ms).
- So shipping this PR alone keeps search + highlighting correct **and** the same speed, while immediately banking the index-size reduction.

## Pairs with monarch-app #1361 (the speedup)

The complementary change ([monarch-app#1361](https://github.com/monarch-initiative/monarch-app/pull/1361)) switches association search to `hl.method=unified`. The unified highlighter is ~**3× faster** than the default (11 ms vs 31 ms in the same benchmark) and reads its offsets from the postings — exactly what `storeOffsetsWithPositions` provides here. Recommended order and rationale:

- **This PR (offsets)**: index-size win; highlighting stays correct + same speed on the default highlighter.
- **#1361 (unified)**: the 3× highlight speedup; reads the compact offsets this PR stores (instead of the bulky term vectors).
- Neither degrades the other; together you get *fast highlighting on a small index*. Either can land first.

### Frontend note (behavioral change from #1361, not this PR)
The unified highlighter emits an empty-string placeholder per non-matching value in a multivalued field (e.g. `object_closure_label_t: ['', '<em>nucleus</em>']` vs the original's `['<em>nucleus</em>']`). Highlight *content* is equivalent, but frontend code that iterates highlight arrays should tolerate `''` entries.

## Scope note

Affects the *shared* `text` type, so it applies to `_t` fields on **both** entity and association cores.

## Follow-ups (separate)

- PreAnalyzedField for `*_closure_label` (pre-tokenize the ~356K distinct labels once instead of ~617M times) — compounds cleanly now that term vectors are gone.
- `string` types for low-cardinality fields; EdgeNGram `minGram` trim on entity autocomplete.

https://claude.ai/code/session_019PxDiQRzBh1EjBWrLzGQ2z
