### PR TITLE
Remove CTD and MEDIC ingests from the KG build

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -21,7 +21,6 @@ nav:
     - Alliance: 'Sources/alliance.md'
     - BGee: 'Sources/bgee.md'
     - BioGrid: 'Sources/biogrid.md'
-    - CTD: 'Sources/ctd.md'
     # - Dictybase: 'Sources/dictybase.md'
     # - Flybase: 'Sources/flybase.md'
     - GO: 'Sources/go.md'

--- a/src/monarch_ingest/ingests.yaml
+++ b/src/monarch_ingest/ingests.yaml
@@ -20,11 +20,6 @@ string_protein_links:
   files:
     - string_protein_links_edges.tsv
 
-ctd_chemical_to_disease:
-  repo: ctd-ingest
-  files:
-    - ctd_chemical_to_disease_edges.tsv
-
 dictybase_gene:
   repo: dictybase-ingest
   files:
@@ -194,11 +189,6 @@ mmrrc:
     - mmrrc_allele_to_genotype_edges.tsv
     - mmrrc_genotype_nodes.tsv
     - mmrrc_genotype_to_phenotype_edges.tsv
-
-medic_drug_to_disease:
-  repo: medic-ingest
-  files:
-    - medic_indication_edges.tsv
 
 cureid:
   repo: cureid-ingest

--- a/src/monarch_ingest/mokg_qc_expect.yaml
+++ b/src/monarch_ingest/mokg_qc_expect.yaml
@@ -37,8 +37,6 @@ edges:
       min: 430000
     biogrid_gene_to_gene_edges:
       min: 1340000
-    ctd_chemical_to_disease_edges:
-      min: 5000
     dictybase_gene_to_phenotype_edges:
       min: 1100
     go_annotation_edges:

--- a/src/monarch_ingest/qc_expect.yaml
+++ b/src/monarch_ingest/qc_expect.yaml
@@ -56,8 +56,6 @@ edges:
       min: 430000
     biogrid_gene_to_gene_edges:
       min: 1340000
-    ctd_chemical_to_disease_edges:
-      min: 5000
     dictybase_gene_to_phenotype_edges:
       min: 1100
     go_annotation_edges:
@@ -111,8 +109,6 @@ edges:
       min: 25000
     mmrrc_genotype_to_phenotype_edges:
       min: 40000
-    medic_indication_edges:
-      min: 7000
     cureid_edges:
       min: 200
     loinc_hierarchy_edges:


### PR DESCRIPTION
Removes the CTD and MEDIC ingests from the KG build temporarily, working towards having a display of treatment associations and we'll want do a more thorough review of these sources along with that feature.  Closes https://github.com/monarch-initiative/monarch-app/issues/1330

## Changes
- **`src/monarch_ingest/ingests.yaml`** — drop the `ctd_chemical_to_disease` (`ctd-ingest`) and `medic_drug_to_disease` (`medic-ingest`) ingest entries.
- **`src/monarch_ingest/qc_expect.yaml`** — remove the `ctd_chemical_to_disease_edges` and `medic_indication_edges` QC expectations.
- **`src/monarch_ingest/mokg_qc_expect.yaml`** — remove the `ctd_chemical_to_disease_edges` QC expectation (MEDIC was not listed here).
- **`mkdocs.yaml`** — remove the dangling `CTD: 'Sources/ctd.md'` nav entry (the referenced doc does not exist; there was no MEDIC nav entry).
