### PR TITLE
Add MMRRC genotype_to_gene transform to the build

### DIFF
--- a/src/monarch_ingest/ingests.yaml
+++ b/src/monarch_ingest/ingests.yaml
@@ -188,6 +188,7 @@ mmrrc:
   files:
     - mmrrc_allele_to_genotype_edges.tsv
     - mmrrc_genotype_nodes.tsv
+    - mmrrc_genotype_to_gene_edges.tsv
     - mmrrc_genotype_to_phenotype_edges.tsv
 
 cureid:

--- a/src/monarch_ingest/qc_expect.yaml
+++ b/src/monarch_ingest/qc_expect.yaml
@@ -107,6 +107,8 @@ edges:
       min: 180000
     mmrrc_allele_to_genotype_edges:
       min: 25000
+    mmrrc_genotype_to_gene_edges:
+      min: 450000
     mmrrc_genotype_to_phenotype_edges:
       min: 40000
     cureid_edges:


### PR DESCRIPTION
The `mmrrc-ingest` release (2026-07-11) now publishes a fourth transform, `mmrrc_genotype_to_gene_edges.tsv` (~528k genotype→gene associations), which our config wasn't pulling in.

- **`ingests.yaml`** — add `mmrrc_genotype_to_gene_edges.tsv` to the `mmrrc` entry's `files:` list so the build fetches it from the release.
- **`qc_expect.yaml`** — add a `mmrrc_genotype_to_gene_edges` count expectation (`min: 450000`), set comfortably below the reported ~528k, matching the pattern of the other MMRRC entries.

https://claude.ai/code/session_01Nh2Vf2T15gyNgn5GstinTY