### PR TITLE
Require koza >=2.6.2 for the sorted closure table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "notebook>=7.3.2,<8",
     "duckdb>=1.3.0,<2",
     "pystow>=0.5.4,<1",
-    "koza[grape]>=2.6.1,<3",
+    "koza[grape]>=2.6.2,<3",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "koza"
-version = "2.6.1"
+version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "biolink-model" },
@@ -2197,9 +2197,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/1c151142a80ad37cf23839a0e932457b15736667952762b84e7a36fba69f/koza-2.6.1.tar.gz", hash = "sha256:376fce55541a7ace62b6f24242e1cb5a8a16ac4d49f8dba3c7626f815b2c55e5", size = 435096, upload-time = "2026-07-08T04:52:28.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ea/27cdf79c0cc060dafdd84874b6e3ec68ce8aad5c37f3b286973c1c82cd5a/koza-2.6.2.tar.gz", hash = "sha256:9f0a62d96fbacbe17b5e0c031ed46d1571df0c8a983c5dc73e955057067e43df", size = 435328, upload-time = "2026-07-28T05:12:26.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/e7/5b4f3ae558f104560cbb9d07158cedbd3cbd6381c1152ad65d2a5cddd6c5/koza-2.6.1-py3-none-any.whl", hash = "sha256:0d0fbe20d4ce545a6926fc888d2f7de5da017a0abedc2ec39430156e15cd3c95", size = 168209, upload-time = "2026-07-08T04:52:27.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/60/1e8379044f3075c80f7ca9196191bded62d50f3535f9743f6e07e3735849/koza-2.6.2-py3-none-any.whl", hash = "sha256:70e2bdb07d938de128df5dcbcb7721e9d2403bde3d8faaa39c8ef24eb2a3d6cc", size = 168602, upload-time = "2026-07-28T05:12:25.604Z" },
 ]
 
 [package.optional-dependencies]
@@ -2692,7 +2692,7 @@ requires-dist = [
     { name = "importlib-metadata", specifier = ">=4.6.1" },
     { name = "kghub-downloader", specifier = ">=0.4.5,<1" },
     { name = "kgx", git = "https://github.com/biolink/kgx.git?branch=rdf-optimization" },
-    { name = "koza", extras = ["grape"], specifier = ">=2.6.1,<3" },
+    { name = "koza", extras = ["grape"], specifier = ">=2.6.2,<3" },
     { name = "linkml", specifier = ">=1.9,<2" },
     { name = "linkml-runtime", specifier = ">=1.7.5,<2" },
     { name = "linkml-solr", specifier = "==0.2.3" },


### PR DESCRIPTION
Bump the koza pin from `>=2.6.1` to `>=2.6.2` so builds ship a KG whose `closure` table is physically sorted by `subject_id`.

## Why

koza 2.6.2 materializes `closure` sorted by `subject_id` (monarch-initiative/koza#244). Without that sort, DuckDB has no way to prune a lookup by subject: there is no secondary index, and on unsorted data every row group's min/max zone map spans the queried values. `WHERE subject_id IN (...)` therefore degrades to a **full sequential scan of all 21.3M rows**, however selective the filter is.

That scan is what makes monarch-app's ducksim similarity backend ~30x slower than the semsimian server it replaces on `/compare` — 0.4 s vs 0.012 s on production hardware — since every comparison scans the whole closure to retrieve ~70 ancestor rows.

Full diagnosis and measurements: monarch-initiative/monarch-app#1374

## Effect

Confirmed on production this morning. The `2026-07-14` stack was serving ducksim against an unsorted closure; applying the same sort to its `monarch-kg.duckdb` took `/compare` from **0.39–0.43 s to ~0.073 s**, a 5.5x improvement, with byte-identical responses. That was a manual patch of a deployed data file — this pin is what makes the next build produce the correct shape on its own.

No monarch-app change is needed: the engine reads `closure` as before, it is simply no longer forced into a full scan.

## Verification

- koza 2.6.2 resolves from PyPI; `uv lock --upgrade-package koza` moves 2.6.1 → 2.6.2 with no other resolution churn
- the `ORDER BY subject_id, predicate_id, object_id` is present in the installed package
- all 67 ingest tests pass

## Note for the next build

The sort adds ~3.5 s to closurize on 21.3M rows and changes physical row order only — row count and a content hash over `(subject_id, predicate_id, object_id)` are unchanged. One intentional side effect: `ARRAY_AGG` output in the derived `closure_id` / `closure_label` tables becomes deterministically ordered rather than scan-order dependent, which is a reproducibility improvement.

https://claude.ai/code/session_012ctzsFfMHaoEUC3yQWansR
