### PR TITLE
Copy exact_synonym into the grounding field type

### DIFF
--- a/scripts/add_entity_copyfields.sh
+++ b/scripts/add_entity_copyfields.sh
@@ -139,6 +139,22 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
     }
 }' http://localhost:8983/solr/entity/schema
 
+# exact_synonym
+#
+# synonym_grounding covers the union synonym field, which mixes exact, broad, narrow and
+# related scopes, so a case-insensitive whole-string hit on it does not tell you the query
+# *names* the entity. The raw exact_synonym field is a case-sensitive string, so matching it
+# directly misses any input whose case differs from the stored value. Copying exact_synonym
+# into the grounding field type gives the one thing neither offers: a case-insensitive
+# whole-string match restricted to the scope that means "this string is another name for me".
+
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+    "add-copy-field": {
+        "source": "exact_synonym",
+        "dest": "exact_synonym_grounding"
+    }
+}' http://localhost:8983/solr/entity/schema
+
 # taxon label
 
 curl -X POST -H 'Content-type:application/json' --data-binary '{


### PR DESCRIPTION
Adds one copy-field to the entity core: `exact_synonym` → `exact_synonym_grounding`.

## Why

Grounding — deciding which entity a piece of text *names*, as opposed to searching for text that's merely relevant — needs a **case-insensitive whole-string match restricted to the synonym scope that means "this string is another name for me"**. The entity core offers neither half of that today:

| field | whole-string, case-insensitive? | right scope? |
|---|---|---|
| `synonym_grounding` | ✅ | ❌ copies the union `synonym` field — exact, broad, narrow and related all mixed |
| `exact_synonym` | ❌ `string`, so case-sensitive | ✅ |

The consequences are both real:

- Matching `synonym_grounding` accepts hits that aren't identifications. `"acute appendicitis"` matches MONDO:0005649 `appendicitis` through a **narrow** synonym — the text is narrower than the term, not another name for it.
- Matching `exact_synonym` directly misses most real input, because named-entity recognisers emit Title Case and upper case while ontology labels are usually lower case. `exact_synonym:"poag"` finds nothing; only `exact_synonym:"POAG"` does.

Copying `exact_synonym` into the existing `grounding` field type (KeywordTokenizer + LowerCase) supplies both at once. It sits alongside the `name_grounding`, `full_name_grounding`, `symbol_grounding` and `synonym_grounding` copies already in this script — `exact_synonym` looks like it was simply overlooked. No new field type and no new dynamic field are needed; `*_grounding` already covers it.

## Verification

Replayed `scripts/add_fieldtypes.sh` and this script against a scratch Solr core, then indexed one document with `exact_synonym: ["POAG", "primary open angle glaucoma"]` and another with `narrow_synonym: ["acute appendicitis"]`:

```
exact_synonym_grounding:"poag"                        -> matched
exact_synonym_grounding:"POAG"                        -> matched
exact_synonym_grounding:"Primary Open Angle Glaucoma" -> matched
exact_synonym_grounding:"acute appendicitis"          -> no match   (narrow scope, correctly refused)
exact_synonym:"poag"                                  -> no match   (case-sensitive, the status quo)
```

## Rollout

Copy-fields only apply at index time, so this has no effect on existing documents and needs a KG build before anything can rely on it. It's additive — no existing field or query changes — so nothing breaks in the meantime.

## Context

monarch-app#1394 adds an exact-match grounding mode to `/v3/api/search`, for callers grounding clinical text (a SemMedDB-derived procedure→disease ingest for the BDC gap analysis). Without this field it has to filter loosely on `synonym_grounding` and then re-check the scope in Python, which means a second query and stops Solr from counting, ordering and paging the result natively. With it, that collapses to a single filter. We're holding #1394 until a build carries this.

## Note, not addressed here

The `*_grounding` dynamic-field POST a few lines above has a trailing comma after `"multiValued": true`, which isn't valid JSON. Solr's parser is lenient enough to accept it, which is why the field exists, but it'd be worth tidying separately.
