### PR TITLE
Download phenio.db from the SemanticSQL CDN, not the raw S3 bucket

### DIFF
--- a/src/monarch_ingest/download.yaml
+++ b/src/monarch_ingest/download.yaml
@@ -25,7 +25,7 @@
   local_name: data/monarch/phenio-relation-graph.tsv.gz
   tag: phenio
 -
-  url: https://s3.amazonaws.com/bbop-sqlite/phenio.db.gz
+  url: https://semanticsql.berkeleybop.io/phenio.db.gz
   local_name: data/monarch/phenio.db.gz
   tag: phenio
 


### PR DESCRIPTION
Closes #711.

Berkeley BOP retired public access to the raw `bbop-sqlite` bucket on **2026-08-28**, so the hardcoded S3 URL in `download.yaml` now returns `AccessDenied`. That breaks the phenio download, and with it any KG build.

```
https://s3.amazonaws.com/bbop-sqlite/phenio.db.gz   ->  403  AccessDenied
https://semanticsql.berkeleybop.io/phenio.db.gz     ->  206
```

One line — only the host changes, the object path is identical.

## Verification

Ran the **actual downloader** against this config rather than just fetching the URL, so the test covers how `kghub-downloader` requests the file, not just whether the CDN serves it:

```
OK: Downloaded https://semanticsql.berkeleybop.io/phenio.db.gz
    successful:   1
    skipped:      0
    unsuccessful: 0
downloaded: True  3455.4 MB
```

## On the User-Agent requirement

The issue is emphatic that a non-default `User-Agent` is required, warning that the CDN's Browser Integrity Check returns 403 to `Python-urllib`, bare `curl`/`wget`, and `requests` defaults. **I could not reproduce that**, and no UA change is included here. Two reasons:

1. The check isn't currently rejecting default agents. All of these returned 206:

   | client | result |
   |---|---|
   | bare `curl` (default UA) | 206 |
   | `curl -A "Python-urllib/3.12"` | 206 |
   | `urllib.request` (default UA) | 206 |
   | `requests` (`python-requests/2.32.4`) | 206 |

2. Even if it were re-enabled, we're already covered: `kghub-downloader` sends `User-Agent: Mozilla/5.0` on every http(s) download — `download.py:212`, in the `http` scheme handler that serves this entry. So the guidance is already satisfied upstream and there's nothing to add in `download.yaml`.

Flagging it rather than silently omitting it, in case the check is environment- or geography-dependent and someone else does hit the 403.

## Note for the migration tracker

This repo had exactly **one** affected URL — `phenio.db.gz`. The other two phenio artifacts (`kg-phenio.tar.gz`, `phenio-relation-graph.gz`) come from GitHub releases and are unaffected. No other `bbop-sqlite` or `s3.amazonaws.com` references exist in the repo.
